### PR TITLE
Stabilize automated performance tests

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: yarn install --immutable
-      - run: cd examples/benchmarking && yarn build && yarn compare markerFacet markerState 88 18000
+      - run: cd examples/benchmarking && yarn build && yarn compare markerFacet markerState 88 19000
 
   mount:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: yarn install --immutable
-      - run: cd examples/benchmarking && yarn build && yarn compare listMemoFacet listMemoState 48
+      - run: cd examples/benchmarking && yarn build && yarn compare listMemoFacet listMemoState 70
 
   marker:
     runs-on: ubuntu-latest

--- a/examples/benchmarking/compare.ts
+++ b/examples/benchmarking/compare.ts
@@ -76,10 +76,7 @@ const compare = async (optionA: string, optionB: string, targetRelativePerforman
 
   console.log(`Relative performance ${optionA}/${optionB}:`, relativePerformance.toFixed(2))
 
-  if (
-    relativePerformance > targetRelativePerformance + ERROR ||
-    relativePerformance < targetRelativePerformance - ERROR
-  ) {
+  if (relativePerformance > targetRelativePerformance + ERROR) {
     console.log('Unable to reach target performance number.')
     process.exit(1)
   }


### PR DESCRIPTION
There is currently a very high variation on the performance numbers we are getting when running via GitHub actions.

This PR does three main changes:
- Increases the time we take to collect samples for the `markerFacet` example.
- Changes the target performance number for `listMemoFacet` to 70.
- Make the script only fail when we go above the target (it would fail when going below as well).

We are still learning what are the best practices on automating this checks, and for the meantime we should still not have them as merge blockers (given they are not yet quite stable).