### PR TITLE
Separate setWithCallback support from set in facet

### DIFF
--- a/packages/@react-facet/core/src/facet/createFacet.spec.ts
+++ b/packages/@react-facet/core/src/facet/createFacet.spec.ts
@@ -191,24 +191,26 @@ describe('cleanup', () => {
   })
 })
 
-it('prevents calling listeners if a setter returns NO_VALUE', () => {
-  const facet = createFacet({ initialValue: 10 })
-  const cleanupMock = jest.fn()
-  const listenerMock = jest.fn().mockReturnValue(cleanupMock)
+describe('setWithCallback', () => {
+  it('prevents calling listeners if a setter returns NO_VALUE', () => {
+    const facet = createFacet({ initialValue: 10 })
+    const cleanupMock = jest.fn()
+    const listenerMock = jest.fn().mockReturnValue(cleanupMock)
 
-  facet.observe(listenerMock)
+    facet.observe(listenerMock)
 
-  // after observing it, the listener is called once with the initial value (but not the cleanup)
-  expect(listenerMock).toHaveBeenCalledTimes(1)
-  expect(listenerMock).toHaveBeenCalledWith(10)
-  expect(cleanupMock).not.toHaveBeenCalled()
+    // after observing it, the listener is called once with the initial value (but not the cleanup)
+    expect(listenerMock).toHaveBeenCalledTimes(1)
+    expect(listenerMock).toHaveBeenCalledWith(10)
+    expect(cleanupMock).not.toHaveBeenCalled()
 
-  listenerMock.mockClear()
-  listenerMock.mockClear()
-  cleanupMock.mockClear()
-  facet.set(() => NO_VALUE)
+    listenerMock.mockClear()
+    listenerMock.mockClear()
+    cleanupMock.mockClear()
+    facet.setWithCallback(() => NO_VALUE)
 
-  // after using a setter callback to return NO_VALUE, the previous cleanup should be called, but not the listener again
-  expect(listenerMock).not.toHaveBeenCalled()
-  expect(cleanupMock).toHaveBeenCalledTimes(1)
+    // after using a setter callback to return NO_VALUE, the previous cleanup should be called, but not the listener again
+    expect(listenerMock).not.toHaveBeenCalled()
+    expect(cleanupMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/@react-facet/core/src/facet/createFacet.ts
+++ b/packages/@react-facet/core/src/facet/createFacet.ts
@@ -7,12 +7,6 @@ interface ListenerCleanupEntry {
   listener: Listener<any>
 }
 
-const isSetterCallback = <V>(
-  setter: V | ((previousValue: Option<V>) => Option<V>),
-): setter is (previousValue: Option<V>) => Option<V> => {
-  return typeof setter === 'function'
-}
-
 export interface FacetOptions<V> {
   initialValue: Option<V>
   startSubscription?: StartSubscription<V>
@@ -84,16 +78,14 @@ export function createFacet<V>({ initialValue, startSubscription, equalityCheck 
   }
 
   return {
-    set: (setter) => {
-      if (isSetterCallback(setter)) {
-        const value = setter(currentValue)
-        if (value === NO_VALUE) {
-          updateToNoValue()
-        } else {
-          update(value)
-        }
+    set: update,
+
+    setWithCallback: (setter) => {
+      const value = setter(currentValue)
+      if (value === NO_VALUE) {
+        updateToNoValue()
       } else {
-        update(setter)
+        update(value)
       }
     },
 

--- a/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
@@ -48,7 +48,7 @@ it('captures the current value of the facet in a function that can be used as ha
   callback.mockClear()
 
   // change the facet
-  demoFacet.set(() => 'new value')
+  demoFacet.setWithCallback(() => 'new value')
 
   result.rerender(<ComponentWithFacetCallback cb={callback} dependency="dependency changed" />)
 

--- a/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
@@ -48,7 +48,7 @@ it('captures the current value of the facet in a function that can be used as ha
   callback.mockClear()
 
   // change the facet
-  demoFacet.setWithCallback(() => 'new value')
+  demoFacet.set('new value')
 
   result.rerender(<ComponentWithFacetCallback cb={callback} dependency="dependency changed" />)
 

--- a/packages/@react-facet/core/src/hooks/useFacetEffect.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetEffect.spec.tsx
@@ -31,7 +31,7 @@ it('triggers the effect on mount with the initial value and on any update of the
 
   // change the facet
   act(() => {
-    demoFacet.setWithCallback(() => 'new value')
+    demoFacet.set('new value')
   })
 
   // verify that it was called again, but with the new value
@@ -95,7 +95,7 @@ describe('cleanup', () => {
     expect(cleanup).not.toHaveBeenCalled()
 
     act(() => {
-      demoFacet.setWithCallback(() => 'new value')
+      demoFacet.set('new value')
     })
 
     // once a new value is triggered we expect that the previous cleanup was called

--- a/packages/@react-facet/core/src/hooks/useFacetEffect.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetEffect.spec.tsx
@@ -31,7 +31,7 @@ it('triggers the effect on mount with the initial value and on any update of the
 
   // change the facet
   act(() => {
-    demoFacet.set(() => 'new value')
+    demoFacet.setWithCallback(() => 'new value')
   })
 
   // verify that it was called again, but with the new value
@@ -95,7 +95,7 @@ describe('cleanup', () => {
     expect(cleanup).not.toHaveBeenCalled()
 
     act(() => {
-      demoFacet.set(() => 'new value')
+      demoFacet.setWithCallback(() => 'new value')
     })
 
     // once a new value is triggered we expect that the previous cleanup was called

--- a/packages/@react-facet/core/src/hooks/useFacetPropSetter.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetPropSetter.ts
@@ -22,7 +22,7 @@ export function useFacetPropSetter<T extends Record<string, any>, Prop extends k
 ): PropSetter<T, Prop> {
   return useMemo(
     () => (value: T[Prop]) => {
-      facet.set((prev) => ({ ...(prev != NO_VALUE ? prev : {}), [prop]: value } as unknown as T))
+      facet.setWithCallback((prev) => ({ ...(prev != NO_VALUE ? prev : {}), [prop]: value } as unknown as T))
     },
     [facet, prop],
   )

--- a/packages/@react-facet/core/src/hooks/useFacetState.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetState.ts
@@ -20,6 +20,19 @@ export const useFacetState = <V>(
    */
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const inlineFacet = useMemo(() => createFacet<V>({ initialValue, equalityCheck }), [])
+  const setter: Setter<V> = (setter) => {
+    if (isSetterCallback(setter)) {
+      inlineFacet.setWithCallback(setter)
+    } else {
+      inlineFacet.set(setter)
+    }
+  }
 
-  return [inlineFacet, inlineFacet.set]
+  return [inlineFacet, setter]
+}
+
+const isSetterCallback = <V>(
+  setter: V | ((previousValue: Option<V>) => Option<V>),
+): setter is (previousValue: Option<V>) => Option<V> => {
+  return typeof setter === 'function'
 }

--- a/packages/@react-facet/core/src/hooks/useFacetUnwrap.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetUnwrap.spec.tsx
@@ -143,7 +143,7 @@ it('re-renders when facet is mutated', () => {
   expect(container.textContent).toBe('foo')
 
   act(() => {
-    demoFacet.set((prev) => {
+    demoFacet.setWithCallback((prev) => {
       if (prev !== NO_VALUE) {
         prev.foo = 'bar'
         return prev
@@ -180,7 +180,7 @@ it('re-renders when facet is mutated to undefined', () => {
   expect(container.textContent).toBe('foo')
 
   act(() => {
-    demoFacet.set((prev) => {
+    demoFacet.setWithCallback((prev) => {
       if (prev !== NO_VALUE) {
         prev.foo = undefined
         return prev

--- a/packages/@react-facet/core/src/hooks/useFacetWrap.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetWrap.spec.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
-import { act, fireEvent, render } from '@react-facet/dom-fiber-testing-library'
+import { render } from '@react-facet/dom-fiber-testing-library'
 import { useFacetWrap } from './useFacetWrap'
 import { useFacetEffect } from './useFacetEffect'
 import { useFacetMap } from './useFacetMap'
 import { createFacet } from '../facet'
-import { useFacetCallback } from './useFacetCallback'
-import { NO_VALUE } from '../types'
 
 it('wraps a value, updating the facet when it changes', () => {
   const mock = jest.fn()

--- a/packages/@react-facet/core/src/hooks/useFacetWrap.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetWrap.spec.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import { render } from '@react-facet/dom-fiber-testing-library'
+import { act, fireEvent, render } from '@react-facet/dom-fiber-testing-library'
 import { useFacetWrap } from './useFacetWrap'
 import { useFacetEffect } from './useFacetEffect'
 import { useFacetMap } from './useFacetMap'
 import { createFacet } from '../facet'
+import { useFacetCallback } from './useFacetCallback'
+import { NO_VALUE } from '../types'
 
 it('wraps a value, updating the facet when it changes', () => {
   const mock = jest.fn()
@@ -95,4 +97,20 @@ it('updates correctly if the facet instance change (ex: via a useFacetMap)', () 
 
   rerender(<TestingComponent concat="456" />)
   expect(container).toHaveTextContent('value 456')
+})
+
+describe('regressions', () => {
+  it('should not immediately call a function when wrapped', () => {
+    const mock = jest.fn()
+
+    const TestingComponent = () => {
+      const handlerFacet = useFacetWrap(mock)
+      useFacetEffect(() => {}, [], handlerFacet)
+      return null
+    }
+
+    render(<TestingComponent />)
+
+    expect(mock).toHaveBeenCalledTimes(0)
+  })
 })

--- a/packages/@react-facet/core/src/types.ts
+++ b/packages/@react-facet/core/src/types.ts
@@ -37,7 +37,8 @@ export interface Facet<T> {
 }
 
 export interface WritableFacet<T> extends Facet<T> {
-  set: Setter<T>
+  set: (value: T) => void
+  setWithCallback: (callback: (previousValue: Option<T>) => Option<T>) => void
 }
 
 export interface Update<V> {


### PR DESCRIPTION
Currently, facets accept both functions and values to be passed into `.set`. This leads to the problem that, if the value is supposed to be a function, `.set` will immediately invoke that function, thinking that it is a callback.

This PR separates this behavior into a different method, `.setWithCallback`. 

Note that `useFacetState` is kept with the same behavior as before, since the intent is to match `useState`'s API from React. 