### PR TITLE
Add support for null values on some built-in equality checks

### DIFF
--- a/packages/@react-facet/core/src/createEqualityChecks.ts
+++ b/packages/@react-facet/core/src/createEqualityChecks.ts
@@ -1,4 +1,28 @@
-import { EqualityCheck } from './types'
+import { EqualityCheck, NO_VALUE, NoValue } from './types'
+
+/**
+ * Creates an equality check that accepts null and undefined values
+ *
+ * @param comparator comparator to be wrapped with the null check
+ */
+export const createNullableEqualityCheck = <T>(comparator: EqualityCheck<T>) => {
+  const check = comparator()
+  let previous: T | null | undefined | NoValue = NO_VALUE
+
+  return (value: T | null | undefined) => {
+    if (value == null || previous == null) {
+      if (value != previous) {
+        previous = value
+        return false
+      } else {
+        return true
+      }
+    }
+
+    previous = value
+    return check(value)
+  }
+}
 
 /**
  * Creates an equality check that tests that the values of all the properties in an object

--- a/packages/@react-facet/core/src/equalityChecks.spec.ts
+++ b/packages/@react-facet/core/src/equalityChecks.spec.ts
@@ -1,4 +1,9 @@
-import { shallowObjectEqualityCheck, strictEqualityCheck, defaultEqualityCheck } from './equalityChecks'
+import {
+  shallowObjectEqualityCheck,
+  strictEqualityCheck,
+  defaultEqualityCheck,
+  nullableShallowObjectEqualityCheck,
+} from './equalityChecks'
 
 describe('shallowObjectEqualityCheck()', () => {
   it('handles matching objects', () => {
@@ -34,9 +39,45 @@ describe('shallowObjectEqualityCheck()', () => {
     expect(equalityCheck({ foo: 'bar', bar: 'baz' })).toBe(false)
     expect(equalityCheck({ foo: 'bar' })).toBe(false)
   })
+})
+
+describe('nullableShallowObjectEqualityCheck()', () => {
+  it('handles matching objects', () => {
+    const equalityCheck = nullableShallowObjectEqualityCheck()
+    expect(equalityCheck({})).toBe(false)
+    expect(equalityCheck({})).toBe(true)
+
+    expect(equalityCheck({ foo: 'bar' })).toBe(false)
+    expect(equalityCheck({ foo: 'bar' })).toBe(true)
+
+    expect(equalityCheck({ foo: 'bar', bar: 'baz' })).toBe(false)
+    expect(equalityCheck({ foo: 'bar', bar: 'baz' })).toBe(true)
+
+    expect(equalityCheck({})).toBe(false)
+    expect(equalityCheck({})).toBe(true)
+
+    expect(equalityCheck({ foo: 'bar' })).toBe(false)
+    expect(equalityCheck({ foo: 'bar' })).toBe(true)
+  })
+
+  it('handles non-matching objects', () => {
+    const equalityCheck = nullableShallowObjectEqualityCheck()
+
+    expect(equalityCheck({ foo: 1 })).toBe(false)
+    expect(equalityCheck({ foo: true })).toBe(false) // Make sure it does a strict type check
+
+    expect(equalityCheck({ foo: 'bar' })).toBe(false)
+    expect(equalityCheck({ foo: 'bars' })).toBe(false)
+
+    expect(equalityCheck({ foo: 'bar', bar: 'baz' })).toBe(false)
+    expect(equalityCheck({ foo: 'baz', bar: undefined })).toBe(false)
+
+    expect(equalityCheck({ foo: 'bar', bar: 'baz' })).toBe(false)
+    expect(equalityCheck({ foo: 'bar' })).toBe(false)
+  })
 
   it('handles null and undefined', () => {
-    const equalityCheck = shallowObjectEqualityCheck()
+    const equalityCheck = nullableShallowObjectEqualityCheck()
 
     expect(equalityCheck({ foo: 1 })).toBe(false)
     expect(equalityCheck({ foo: 1 })).toBe(true)

--- a/packages/@react-facet/core/src/equalityChecks.spec.ts
+++ b/packages/@react-facet/core/src/equalityChecks.spec.ts
@@ -34,6 +34,20 @@ describe('shallowObjectEqualityCheck()', () => {
     expect(equalityCheck({ foo: 'bar', bar: 'baz' })).toBe(false)
     expect(equalityCheck({ foo: 'bar' })).toBe(false)
   })
+
+  it('handles null and undefined', () => {
+    const equalityCheck = shallowObjectEqualityCheck()
+
+    expect(equalityCheck({ foo: 1 })).toBe(false)
+    expect(equalityCheck({ foo: 1 })).toBe(true)
+
+    expect(equalityCheck(null)).toBe(false)
+
+    expect(equalityCheck({ foo: 1 })).toBe(false)
+    expect(equalityCheck({ foo: 1 })).toBe(true)
+
+    expect(equalityCheck(undefined)).toBe(false)
+  })
 })
 
 describe('strictEqualityCheck', () => {

--- a/packages/@react-facet/core/src/equalityChecks.ts
+++ b/packages/@react-facet/core/src/equalityChecks.ts
@@ -25,21 +25,50 @@ export const strictEqualityCheck = <T extends Immutable | Function>() => {
 /**
  * Equality check that verifies the values of each key of an object.
  * Each value must be a primitive (boolean, number or string)
+ *
+ * For null or undefined values see nullableShallowObjectEqualityCheck
  */
-export const shallowObjectEqualityCheck = () =>
+export const shallowObjectEqualityCheck = createUniformObjectEqualityCheck<ObjectWithImmutables>(strictEqualityCheck)
+
+/**
+ * Does a shallow object equality check for each element in an array
+ *
+ * For null or undefined values see nullableShallowObjectArrayEqualityCheck
+ */
+export const shallowObjectArrayEqualityCheck =
+  createUniformArrayEqualityCheck<ObjectWithImmutables>(shallowObjectEqualityCheck)
+
+/**
+ * Shallow equality check of primitives in an array
+ *
+ * For null or undefined values see nullableShallowArrayEqualityCheck
+ */
+export const shallowArrayEqualityCheck = createUniformArrayEqualityCheck<Immutable>(strictEqualityCheck)
+
+/**
+ * Equality check that verifies the values of each key of an object.
+ * Each value must be a primitive (boolean, number or string)
+ *
+ * Supports nullable values
+ */
+export const nullableShallowObjectEqualityCheck = () =>
   createNullableEqualityCheck(createUniformObjectEqualityCheck<ObjectWithImmutables>(strictEqualityCheck))
 
 /**
  * Does a shallow object equality check for each element in an array
+ *
+ * Supports nullable values
  */
-export const shallowObjectArrayEqualityCheck = createNullableEqualityCheck(
+export const nullableShallowObjectArrayEqualityCheck = createNullableEqualityCheck(
   createUniformArrayEqualityCheck<ObjectWithImmutables>(shallowObjectEqualityCheck),
 )
 
 /**
  * Shallow equality check of primitives in an array
+ *
+ * Supports nullable values
  */
-export const shallowArrayEqualityCheck = createNullableEqualityCheck(
+export const nullableShallowArrayEqualityCheck = createNullableEqualityCheck(
   createUniformArrayEqualityCheck<Immutable>(strictEqualityCheck),
 )
 

--- a/packages/@react-facet/core/src/equalityChecks.ts
+++ b/packages/@react-facet/core/src/equalityChecks.ts
@@ -1,5 +1,5 @@
 import { createUniformArrayEqualityCheck, createUniformObjectEqualityCheck } from './createEqualityChecks'
-import { ObjectWithImmutables, Immutable, Option, NO_VALUE } from './types'
+import { ObjectWithImmutables, Immutable, Option, NO_VALUE, NoValue } from './types'
 
 /**
  * Checks that the current value is exactly the same as the other previous one. Accepts value of type
@@ -22,7 +22,24 @@ export const strictEqualityCheck = <T extends Immutable | Function>() => {
  * Equality check that verifies the values of each key of an object.
  * Each value must be a primitive (boolean, number or string)
  */
-export const shallowObjectEqualityCheck = createUniformObjectEqualityCheck<ObjectWithImmutables>(strictEqualityCheck)
+export const shallowObjectEqualityCheck = () => {
+  const check = createUniformObjectEqualityCheck<ObjectWithImmutables>(strictEqualityCheck)()
+  let previous: ObjectWithImmutables | null | undefined | NoValue = NO_VALUE
+
+  return (value: ObjectWithImmutables | null | undefined) => {
+    if (value == null || previous == null) {
+      if (value != previous) {
+        previous = value
+        return false
+      } else {
+        return true
+      }
+    }
+
+    previous = value
+    return check(value)
+  }
+}
 
 /**
  * Does a shallow object equality check for each element in an array

--- a/packages/@react-facet/core/src/equalityChecks.ts
+++ b/packages/@react-facet/core/src/equalityChecks.ts
@@ -1,5 +1,9 @@
-import { createUniformArrayEqualityCheck, createUniformObjectEqualityCheck } from './createEqualityChecks'
-import { ObjectWithImmutables, Immutable, Option, NO_VALUE, NoValue } from './types'
+import {
+  createUniformArrayEqualityCheck,
+  createUniformObjectEqualityCheck,
+  createNullableEqualityCheck,
+} from './createEqualityChecks'
+import { ObjectWithImmutables, Immutable, Option, NO_VALUE } from './types'
 
 /**
  * Checks that the current value is exactly the same as the other previous one. Accepts value of type
@@ -22,35 +26,22 @@ export const strictEqualityCheck = <T extends Immutable | Function>() => {
  * Equality check that verifies the values of each key of an object.
  * Each value must be a primitive (boolean, number or string)
  */
-export const shallowObjectEqualityCheck = () => {
-  const check = createUniformObjectEqualityCheck<ObjectWithImmutables>(strictEqualityCheck)()
-  let previous: ObjectWithImmutables | null | undefined | NoValue = NO_VALUE
-
-  return (value: ObjectWithImmutables | null | undefined) => {
-    if (value == null || previous == null) {
-      if (value != previous) {
-        previous = value
-        return false
-      } else {
-        return true
-      }
-    }
-
-    previous = value
-    return check(value)
-  }
-}
+export const shallowObjectEqualityCheck = () =>
+  createNullableEqualityCheck(createUniformObjectEqualityCheck<ObjectWithImmutables>(strictEqualityCheck))
 
 /**
  * Does a shallow object equality check for each element in an array
  */
-export const shallowObjectArrayEqualityCheck =
-  createUniformArrayEqualityCheck<ObjectWithImmutables>(shallowObjectEqualityCheck)
+export const shallowObjectArrayEqualityCheck = createNullableEqualityCheck(
+  createUniformArrayEqualityCheck<ObjectWithImmutables>(shallowObjectEqualityCheck),
+)
 
 /**
  * Shallow equality check of primitives in an array
  */
-export const shallowArrayEqualityCheck = createUniformArrayEqualityCheck<Immutable>(strictEqualityCheck)
+export const shallowArrayEqualityCheck = createNullableEqualityCheck(
+  createUniformArrayEqualityCheck<Immutable>(strictEqualityCheck),
+)
 
 /**
  * The default equality check that assumes data can be mutated.


### PR DESCRIPTION
Extends a few of the built-in equality checks to also accept `null` and `undefined` as values. It is not uncommon for selectors or maps to have "optional" return values. So having it supported in the built-in checks makes them available to be used in more situations.

Added new the checks:
- `nullableShallowObjectEqualityCheck`
- `nullableShallowObjectArrayEqualityCheck`
- `nullableShallowArrayEqualityCheck`

TODO:

- [ ] After merging we will need to update the documentation pages