### PR TITLE
Add index to Map tests

### DIFF
--- a/packages/@react-facet/core/src/components/Map.spec.tsx
+++ b/packages/@react-facet/core/src/components/Map.spec.tsx
@@ -11,10 +11,11 @@ it('renders all items in a Facet of array', () => {
     initialValue: [{ a: '1' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }],
   })
 
-  const ExampleContent = ({ item, index }: { item: Facet<Input>, index: number }) => {
+  const ExampleContent = ({ item, index }: { item: Facet<Input>; index: number }) => {
     return (
       <span>
         <fast-text text={useFacetMap(({ a }) => a, [], [item])} />
+        <span>{index}</span>
       </span>
     )
   }
@@ -54,9 +55,10 @@ it('unmounts components when the array reduces in size', () => {
     initialValue: [{ value: '1' }, { value: '2' }, { value: '3' }, { value: '4' }, { value: '5' }],
   })
 
-  const Item = ({ item, index }: { item: Facet<Item>, index: number }) => (
+  const Item = ({ item, index }: { item: Facet<Item>; index: number }) => (
     <span>
       <fast-text text={useFacetMap(({ value }) => value, [], [item])} />
+      <span>{index}</span>
     </span>
   )
 
@@ -101,7 +103,7 @@ it('updates only items that have changed', () => {
 
   const mock = jest.fn()
 
-  const ExampleContent = ({ item, index}: { item: Facet<Input>, index: number }) => {
+  const ExampleContent = ({ item }: { item: Facet<Input> }) => {
     useFacetEffect(mock, [], [item])
     return null
   }
@@ -123,7 +125,7 @@ it('updates only items that have changed', () => {
   const Example = () => {
     return (
       <Map array={data} equalityCheck={inputEqualityCheck}>
-        {(item, index) => <ExampleContent item={item} index={index} />}
+        {(item) => <ExampleContent item={item} />}
       </Map>
     )
   }

--- a/packages/@react-facet/core/src/components/Map.spec.tsx
+++ b/packages/@react-facet/core/src/components/Map.spec.tsx
@@ -11,7 +11,7 @@ it('renders all items in a Facet of array', () => {
     initialValue: [{ a: '1' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }],
   })
 
-  const ExampleContent = ({ item }: { item: Facet<Input> }) => {
+  const ExampleContent = ({ item, index }: { item: Facet<Input>, index: number }) => {
     return (
       <span>
         <fast-text text={useFacetMap(({ a }) => a, [], [item])} />
@@ -33,7 +33,7 @@ it('renders all items in a Facet of array', () => {
   const Example = () => {
     return (
       <Map array={data} equalityCheck={inputEqualityCheck}>
-        {(item) => <ExampleContent item={item} />}
+        {(item, index) => <ExampleContent item={item} index={index} />}
       </Map>
     )
   }
@@ -54,7 +54,7 @@ it('unmounts components when the array reduces in size', () => {
     initialValue: [{ value: '1' }, { value: '2' }, { value: '3' }, { value: '4' }, { value: '5' }],
   })
 
-  const Item = ({ item }: { item: Facet<Item> }) => (
+  const Item = ({ item, index }: { item: Facet<Item>, index: number }) => (
     <span>
       <fast-text text={useFacetMap(({ value }) => value, [], [item])} />
     </span>
@@ -77,7 +77,7 @@ it('unmounts components when the array reduces in size', () => {
   const Example = () => {
     return (
       <Map array={data} equalityCheck={itemEqualityCheck}>
-        {(item) => <Item item={item} />}
+        {(item, index) => <Item item={item} index={index} />}
       </Map>
     )
   }
@@ -101,7 +101,7 @@ it('updates only items that have changed', () => {
 
   const mock = jest.fn()
 
-  const ExampleContent = ({ item }: { item: Facet<Input> }) => {
+  const ExampleContent = ({ item, index}: { item: Facet<Input>, index: number }) => {
     useFacetEffect(mock, [], [item])
     return null
   }
@@ -123,7 +123,7 @@ it('updates only items that have changed', () => {
   const Example = () => {
     return (
       <Map array={data} equalityCheck={inputEqualityCheck}>
-        {(item) => <ExampleContent item={item} />}
+        {(item, index) => <ExampleContent item={item} index={index} />}
       </Map>
     )
   }

--- a/packages/@react-facet/core/src/components/__snapshots__/Map.spec.tsx.snap
+++ b/packages/@react-facet/core/src/components/__snapshots__/Map.spec.tsx.snap
@@ -4,18 +4,33 @@ exports[`renders all items in a Facet of array 1`] = `
 <div>
   <span>
     1
+    <span>
+      0
+    </span>
   </span>
   <span>
     2
+    <span>
+      1
+    </span>
   </span>
   <span>
     3
+    <span>
+      2
+    </span>
   </span>
   <span>
     4
+    <span>
+      3
+    </span>
   </span>
   <span>
     5
+    <span>
+      4
+    </span>
   </span>
 </div>
 `;
@@ -24,18 +39,33 @@ exports[`unmounts components when the array reduces in size 1`] = `
 <div>
   <span>
     1
+    <span>
+      0
+    </span>
   </span>
   <span>
     2
+    <span>
+      1
+    </span>
   </span>
   <span>
     3
+    <span>
+      2
+    </span>
   </span>
   <span>
     4
+    <span>
+      3
+    </span>
   </span>
   <span>
     5
+    <span>
+      4
+    </span>
   </span>
 </div>
 `;
@@ -44,9 +74,15 @@ exports[`unmounts components when the array reduces in size 2`] = `
 <div>
   <span>
     1
+    <span>
+      0
+    </span>
   </span>
   <span>
     2
+    <span>
+      1
+    </span>
   </span>
 </div>
 `;


### PR DESCRIPTION
The `<Map>` component sends a facet containing both an item value and an index of that item, however the index value was missing from our units tests. This has now been amended.

```tsx
<Map array={data} equalityCheck={inputEqualityCheck}>
  {(item, index) => <ExampleContent item={item} index={index} />}
</Map>
```