### PR TITLE
Deferred Mount feature: DeferredMountWithCallback

### DIFF
--- a/packages/@react-facet/deferred-mount/README.md
+++ b/packages/@react-facet/deferred-mount/README.md
@@ -4,9 +4,9 @@ React Facet is a state management for performant game UIs. For more information 
 
 This package allows you to defer the mounting of a component to the next frame. By wrapping components on a big list you can keep the frame time low while everything is mounted.
 
-When the `DeferredMountProvider` is used, it requires that there is at least one descendent as a `DeferredMount`, otherwise it will wait forever as `deferring`.
+When the `DeferredMountProvider` is used, it requires that there is at least one descendent as a `DeferredMount` or `DeferredMountWithCallback`, otherwise it will wait forever as `deferring`.
 
-## Example
+### Example
 
 In the example below it will mount:
 
@@ -46,3 +46,34 @@ render(
 ```
 
 The `frameTimeBudget` prop allows the tweaking of how much time the library has available to do work on a given frame (by default it targets 60fps).
+
+## Deferring Asynchronous Renders
+
+Some components may need to wait some time before they can be considered fully rendered (for example if they are fetching data). For these cases you should use `DeferredMountWithCallback` with the `useNotifyMountComplete` hook.
+
+### Example
+
+```tsx
+const DelayedComponent = () => {
+  const notifyMountComplete = useNotifyMountComplete()
+  const [data, setData] = useState()
+
+  useEffect(() => {
+    fetch('mock-api').then((data) => {
+      setData(data)
+      notifyMountComplete()
+    })
+  }, [notifyMountComplete])
+
+  return <div>{data}</div>
+}
+
+render(
+  <DeferredMountProvider>
+    <DeferredMountWithCallback>
+      <DelayedComponent />
+    </DeferredMountWithCallback>
+  </DeferredMountProvider>,
+  document.getElementById('root'),
+)
+```


### PR DESCRIPTION
## Overview

The `DeferredMount` component will wait for an initial render before marking the render as complete. This works for simple components, but falls apart for components that load content asynchronously.

This PR introduces a new component and hook to handle those cases: `DeferredMountWithCallback` and `useNotifyMountComplete`.

## Implementation

Originally, the `DeferredMountProvider` would loop through a queue of any deferred children and call a trigger function that causes them to render; trying to render as many as possible within a given time budget. 

As an addition to this, it will now check to see if that trigger function returns a callback which is then used to pause the processing of the queue until the callback is run. 

## Example

```tsx
const DelayedComponent = () => {
  const notifyMountComplete = useNotifyMountComplete()
  const [data, setData] = useState()

  useEffect(() => {
    fetch('mock-api').then((data) => {
      setData(data)
      notifyMountComplete()
    })
  }, [notifyMountComplete])

  return <div>{data}</div>
}

render(
  <DeferredMountProvider>
    <DeferredMountWithCallback>
      <DelayedComponent />
    </DeferredMountWithCallback>
  </DeferredMountProvider>,
  document.getElementById('root'),
)
```