### PR TITLE
Make the types defined in the hooks more dynamic

### DIFF
--- a/packages/@react-facet/core/src/hooks/useFacetCallback.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.ts
@@ -1,96 +1,6 @@
 import { useCallback, useLayoutEffect, useRef } from 'react'
 import { NoValue } from '..'
-import { Facet, NO_VALUE, Option } from '../types'
-
-export function useFacetCallback<M, V, K extends unknown[]>(
-  callback: (v: V) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [Facet<V>],
-): (...args: K) => M | NoValue
-
-export function useFacetCallback<M, V, V1, K extends unknown[]>(
-  callback: (v: V, v1: V1) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>],
-): (...args: K) => M | NoValue
-
-export function useFacetCallback<M, V, V1, V2, K extends unknown[]>(
-  callback: (v: V, v1: V1, v2: V2) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>],
-): (...args: K) => M | NoValue
-
-export function useFacetCallback<M, V, V1, V2, V3, K extends unknown[]>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>],
-): (...args: K) => M | NoValue
-
-export function useFacetCallback<M, V, V1, V2, V3, V4, K extends unknown[]>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>],
-): (...args: K) => M | NoValue
-
-export function useFacetCallback<M, V, V1, V2, V3, V4, V5, K extends unknown[]>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>],
-): (...args: K) => M | NoValue
-
-export function useFacetCallback<M, V, V1, V2, V3, V4, V5, V6, K extends unknown[]>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>],
-): (...args: K) => M | NoValue
-
-export function useFacetCallback<M, V, V1, V2, V3, V4, V5, V6, V7, K extends unknown[]>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>],
-): (...args: K) => M | NoValue
-
-export function useFacetCallback<M, V, V1, V2, V3, V4, V5, V6, V7, V8, K extends unknown[]>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>, Facet<V8>],
-): (...args: K) => M | NoValue
-
-export function useFacetCallback<M, V, V1, V2, V3, V4, V5, V6, V7, V8, V9, K extends unknown[]>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8, v9: V9) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>, Facet<V8>, Facet<V9>],
-): (...args: K) => M | NoValue
-
-export function useFacetCallback<M, V, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, K extends unknown[]>(
-  callback: (
-    v: V,
-    v1: V1,
-    v2: V2,
-    v3: V3,
-    v4: V4,
-    v5: V5,
-    v6: V6,
-    v7: V7,
-    v8: V8,
-    v9: V9,
-    v10: V10,
-  ) => (...args: K) => M,
-  dependencies: unknown[],
-  facet: [
-    Facet<V>,
-    Facet<V1>,
-    Facet<V2>,
-    Facet<V3>,
-    Facet<V4>,
-    Facet<V5>,
-    Facet<V6>,
-    Facet<V7>,
-    Facet<V8>,
-    Facet<V9>,
-    Facet<V10>,
-  ],
-): (...args: K) => M | NoValue
+import { Facet, NO_VALUE, Option, ExtractFacetValues } from '../types'
 
 /**
  * Creates a callback that depends on the value of a facet.
@@ -103,10 +13,10 @@ export function useFacetCallback<M, V, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, 
  * We pass the dependencies of the callback as the second argument so we can leverage the eslint-plugin-react-hooks option for additionalHooks.
  * Having this as the second argument allows the linter to work.
  */
-export function useFacetCallback<M>(
-  callback: (...args: unknown[]) => (...args: unknown[]) => M,
+export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y], K extends unknown[]>(
+  callback: (...args: ExtractFacetValues<T>) => (...args: K) => M,
   dependencies: unknown[],
-  facets: Facet<unknown>[],
+  facets: T,
 ): (...args: unknown[]) => M | NoValue {
   const facetsRef = useRef<Option<unknown>[]>(facets.map(() => NO_VALUE))
 
@@ -137,7 +47,7 @@ export function useFacetCallback<M>(
         if (value === NO_VALUE) return NO_VALUE
       }
 
-      return callbackMemoized(...values)(...args)
+      return callbackMemoized(...(values as ExtractFacetValues<T>))(...(args as K))
     },
     [callbackMemoized, facetsRef],
   )

--- a/packages/@react-facet/core/src/hooks/useFacetEffect.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetEffect.tsx
@@ -1,79 +1,5 @@
 import { useCallback, useEffect } from 'react'
-import { Facet, Unsubscribe, Cleanup, NO_VALUE } from '../types'
-
-export function useFacetEffect<V>(callback: (v: V) => void | Cleanup, dependencies: unknown[], facet: [Facet<V>]): void
-
-export function useFacetEffect<V, V1>(
-  callback: (v: V, v1: V1) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>],
-): void
-
-export function useFacetEffect<V, V1, V2>(
-  callback: (v: V, v1: V1, v2: V2) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>],
-): void
-
-export function useFacetEffect<V, V1, V2, V3>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>],
-): void
-
-export function useFacetEffect<V, V1, V2, V3, V4>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>],
-): void
-
-export function useFacetEffect<V, V1, V2, V3, V4, V5>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>],
-): void
-
-export function useFacetEffect<V, V1, V2, V3, V4, V5, V6>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>],
-): void
-
-export function useFacetEffect<V, V1, V2, V3, V4, V5, V6, V7>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>],
-): void
-
-export function useFacetEffect<V, V1, V2, V3, V4, V5, V6, V7, V8>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>, Facet<V8>],
-): void
-
-export function useFacetEffect<V, V1, V2, V3, V4, V5, V6, V7, V8, V9>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8, v9: V9) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>, Facet<V8>, Facet<V9>],
-): void
-
-export function useFacetEffect<V, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8, v9: V9, v10: V10) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [
-    Facet<V>,
-    Facet<V1>,
-    Facet<V2>,
-    Facet<V3>,
-    Facet<V4>,
-    Facet<V5>,
-    Facet<V6>,
-    Facet<V7>,
-    Facet<V8>,
-    Facet<V9>,
-    Facet<V10>,
-  ],
-): void
+import { Facet, Unsubscribe, Cleanup, NO_VALUE, ExtractFacetValues } from '../types'
 
 /**
  * Allows running an effect based on facet updates. Similar to React's useEffect.
@@ -85,13 +11,13 @@ export function useFacetEffect<V, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10>(
  * We pass the dependencies of the callback as the second argument so we can leverage the eslint-plugin-react-hooks option for additionalHooks.
  * Having this as the second argument allows the linter to work.
  */
-export function useFacetEffect(
-  effect: (...args: unknown[]) => void | Cleanup,
+export function useFacetEffect<Y extends Facet<unknown>[], T extends [...Y]>(
+  effect: (...args: ExtractFacetValues<T>) => void | Cleanup,
   dependencies: unknown[],
-  facets: Facet<unknown>[],
+  facets: T,
 ) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const effectMemoized = useCallback(effect, dependencies)
+  const effectMemoized = useCallback(effect as (...args: unknown[]) => ReturnType<typeof effect>, dependencies)
 
   useEffect(() => {
     if (facets.length === 1) {
@@ -113,7 +39,7 @@ export function useFacetEffect(
             cleanup()
           }
 
-          cleanup = effect(...values)
+          cleanup = effect(...(values as ExtractFacetValues<T>))
         }
       })
     })

--- a/packages/@react-facet/core/src/hooks/useFacetLayoutEffect.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetLayoutEffect.ts
@@ -1,83 +1,5 @@
 import { useCallback, useLayoutEffect } from 'react'
-import { Facet, Unsubscribe, Cleanup, NO_VALUE } from '../types'
-
-export function useFacetLayoutEffect<V>(
-  callback: (v: V) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>],
-): void
-
-export function useFacetLayoutEffect<V, V1>(
-  callback: (v: V, v1: V1) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>],
-): void
-
-export function useFacetLayoutEffect<V, V1, V2>(
-  callback: (v: V, v1: V1, v2: V2) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>],
-): void
-
-export function useFacetLayoutEffect<V, V1, V2, V3>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>],
-): void
-
-export function useFacetLayoutEffect<V, V1, V2, V3, V4>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>],
-): void
-
-export function useFacetLayoutEffect<V, V1, V2, V3, V4, V5>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>],
-): void
-
-export function useFacetLayoutEffect<V, V1, V2, V3, V4, V5, V6>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>],
-): void
-
-export function useFacetLayoutEffect<V, V1, V2, V3, V4, V5, V6, V7>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>],
-): void
-
-export function useFacetLayoutEffect<V, V1, V2, V3, V4, V5, V6, V7, V8>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>, Facet<V8>],
-): void
-
-export function useFacetLayoutEffect<V, V1, V2, V3, V4, V5, V6, V7, V8, V9>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8, v9: V9) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>, Facet<V8>, Facet<V9>],
-): void
-
-export function useFacetLayoutEffect<V, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10>(
-  callback: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8, v9: V9, v10: V10) => void | Cleanup,
-  dependencies: unknown[],
-  facet: [
-    Facet<V>,
-    Facet<V1>,
-    Facet<V2>,
-    Facet<V3>,
-    Facet<V4>,
-    Facet<V5>,
-    Facet<V6>,
-    Facet<V7>,
-    Facet<V8>,
-    Facet<V9>,
-    Facet<V10>,
-  ],
-): void
+import { Facet, Unsubscribe, Cleanup, NO_VALUE, ExtractFacetValues } from '../types'
 
 /**
  * Allows running an effect based on facet updates. Similar to React's useLayoutEffect.
@@ -89,13 +11,13 @@ export function useFacetLayoutEffect<V, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10>
  * We pass the dependencies of the callback as the second argument so we can leverage the eslint-plugin-react-hooks option for additionalHooks.
  * Having this as the second argument allows the linter to work.
  */
-export function useFacetLayoutEffect(
-  effect: (...args: unknown[]) => void | Cleanup,
+export function useFacetLayoutEffect<Y extends Facet<unknown>[], T extends [...Y]>(
+  effect: (...args: ExtractFacetValues<T>) => void | Cleanup,
   dependencies: unknown[],
-  facets: Facet<unknown>[],
+  facets: T,
 ) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const effectMemoized = useCallback(effect, dependencies)
+  const effectMemoized = useCallback(effect as (...args: unknown[]) => ReturnType<typeof effect>, dependencies)
 
   useLayoutEffect(() => {
     if (facets.length === 1) {
@@ -117,7 +39,7 @@ export function useFacetLayoutEffect(
             cleanup()
           }
 
-          cleanup = effect(...values)
+          cleanup = effect(...(values as ExtractFacetValues<T>))
         }
       })
     })

--- a/packages/@react-facet/core/src/hooks/useFacetMap.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetMap.ts
@@ -1,96 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { defaultEqualityCheck } from '../equalityChecks'
 import { mapFacetsLightweight } from '../mapFacets'
-import { EqualityCheck, Facet, NoValue, Value } from '../types'
-
-export function useFacetMap<M extends Value, V>(
-  selector: (v: V) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMap<M extends Value, V, V1>(
-  selector: (v: V, v1: V1) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMap<M extends Value, V, V1, V2>(
-  selector: (v: V, v1: V1, v2: V2) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMap<M extends Value, V, V1, V2, V3>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMap<M extends Value, V, V1, V2, V3, V4>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMap<M extends Value, V, V1, V2, V3, V4, V5>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMap<M extends Value, V, V1, V2, V3, V4, V5, V6>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMap<M extends Value, V, V1, V2, V3, V4, V5, V6, V7>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMap<M extends Value, V, V1, V2, V3, V4, V5, V6, V7, V8>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>, Facet<V8>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMap<M extends Value, V, V1, V2, V3, V4, V5, V6, V7, V8, V9>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8, v9: V9) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>, Facet<V8>, Facet<V9>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMap<M extends Value, V, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8, v9: V9, v10: V10) => M | NoValue,
-  dependencies: unknown[],
-  facet: [
-    Facet<V>,
-    Facet<V1>,
-    Facet<V2>,
-    Facet<V3>,
-    Facet<V4>,
-    Facet<V5>,
-    Facet<V6>,
-    Facet<V7>,
-    Facet<V8>,
-    Facet<V9>,
-    Facet<V10>,
-  ],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
+import { EqualityCheck, Facet, NoValue, Value, ExtractFacetValues } from '../types'
 
 /**
  * Helper hook that allows mapping a value from a facet with local variables/props in a React component
@@ -105,14 +16,14 @@ export function useFacetMap<M extends Value, V, V1, V2, V3, V4, V5, V6, V7, V8, 
  *
  * @returns a new facet definition that can be consumed as a regular facet
  */
-export function useFacetMap<M extends Value>(
-  selector: (...args: unknown[]) => M | NoValue,
+export function useFacetMap<M extends Value, Y extends Facet<unknown>[], T extends [...Y]>(
+  selector: (...args: ExtractFacetValues<T>) => M | NoValue,
   dependencies: unknown[],
-  facets: Facet<unknown>[],
+  facets: T,
   equalityCheck: EqualityCheck<M> = defaultEqualityCheck,
 ): Facet<M> {
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const selectorMemoized = useCallback(selector, dependencies)
+  const selectorMemoized = useCallback(selector as (...args: unknown[]) => ReturnType<typeof selector>, dependencies)
 
   const facetComposition = useMemo<Facet<M>>(() => {
     return mapFacetsLightweight(facets, selectorMemoized, equalityCheck)

--- a/packages/@react-facet/core/src/hooks/useFacetMemo.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetMemo.ts
@@ -1,96 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { defaultEqualityCheck } from '../equalityChecks'
 import { mapFacetsCached } from '../mapFacets'
-import { EqualityCheck, Facet, NoValue, Value } from '../types'
-
-export function useFacetMemo<M extends Value, V>(
-  selector: (v: V) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMemo<M extends Value, V, V1>(
-  selector: (v: V, v1: V1) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMemo<M extends Value, V, V1, V2>(
-  selector: (v: V, v1: V1, v2: V2) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMemo<M extends Value, V, V1, V2, V3>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMemo<M extends Value, V, V1, V2, V3, V4>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMemo<M extends Value, V, V1, V2, V3, V4, V5>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMemo<M extends Value, V, V1, V2, V3, V4, V5, V6>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMemo<M extends Value, V, V1, V2, V3, V4, V5, V6, V7>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMemo<M extends Value, V, V1, V2, V3, V4, V5, V6, V7, V8>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>, Facet<V8>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMemo<M extends Value, V, V1, V2, V3, V4, V5, V6, V7, V8, V9>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8, v9: V9) => M | NoValue,
-  dependencies: unknown[],
-  facet: [Facet<V>, Facet<V1>, Facet<V2>, Facet<V3>, Facet<V4>, Facet<V5>, Facet<V6>, Facet<V7>, Facet<V8>, Facet<V9>],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
-
-export function useFacetMemo<M extends Value, V, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10>(
-  selector: (v: V, v1: V1, v2: V2, v3: V3, v4: V4, v5: V5, v6: V6, v7: V7, v8: V8, v9: V9, v10: V10) => M | NoValue,
-  dependencies: unknown[],
-  facet: [
-    Facet<V>,
-    Facet<V1>,
-    Facet<V2>,
-    Facet<V3>,
-    Facet<V4>,
-    Facet<V5>,
-    Facet<V6>,
-    Facet<V7>,
-    Facet<V8>,
-    Facet<V9>,
-    Facet<V10>,
-  ],
-  equalityCheck?: EqualityCheck<M>,
-): Facet<M>
+import { EqualityCheck, Facet, NoValue, Value, ExtractFacetValues } from '../types'
 
 /**
  * Helper hook that allows mapping a value from a facet with local variables/props in a React component
@@ -105,14 +16,14 @@ export function useFacetMemo<M extends Value, V, V1, V2, V3, V4, V5, V6, V7, V8,
  *
  * @returns a new facet definition that can be consumed as a regular facet
  */
-export function useFacetMemo<M extends Value>(
-  selector: (...args: unknown[]) => M | NoValue,
+export function useFacetMemo<M extends Value, Y extends Facet<unknown>[], T extends [...Y]>(
+  selector: (...args: ExtractFacetValues<T>) => M | NoValue,
   dependencies: unknown[],
-  facets: Facet<unknown>[],
+  facets: T,
   equalityCheck: EqualityCheck<M> = defaultEqualityCheck,
 ): Facet<M> {
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const selectorMemoized = useCallback(selector, dependencies)
+  const selectorMemoized = useCallback(selector as (...args: unknown[]) => ReturnType<typeof selector>, dependencies)
 
   const facetComposition = useMemo<Facet<M>>(() => {
     return mapFacetsCached(facets, selectorMemoized, equalityCheck)

--- a/packages/@react-facet/core/src/types.ts
+++ b/packages/@react-facet/core/src/types.ts
@@ -13,6 +13,10 @@ export interface EqualityCheck<T> {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Value = string | number | boolean | undefined | null | [] | Record<string, any>
 
+export type ExtractFacetValues<T extends ReadonlyArray<Facet<unknown>>> = {
+  [K in keyof T]: T[K] extends Facet<infer V> ? V : never
+}
+
 export const FACET_FACTORY = Symbol('facet-factory')
 
 export interface FacetFactory<T> {


### PR DESCRIPTION
## Overview
I made the type definitions for some of our hooks a bit more dynamic by inferring them while also using variadic tuple types to keep their position.

I made a short video here that shows that the selector is still aware of the position of the arguments, and that the hooks cant be used with anything other than facets:

https://user-images.githubusercontent.com/12787673/153181877-b9a8a02b-f1ae-4a49-a115-aadae950da10.mov





I only changed the types of the hooks for now - since that is the more public API. The other layers still expect `Array<unknown>` for the selector function arguments, hence the type castings. Changing the remaining layers requires a bit more work. Maybe we could address them in separate PRs?