### PR TITLE
Add support for id attribute

### DIFF
--- a/packages/@react-facet/dom-fiber/src/setupHostConfig.spec.tsx
+++ b/packages/@react-facet/dom-fiber/src/setupHostConfig.spec.tsx
@@ -39,6 +39,11 @@ describe('mount', () => {
       expect(root).toContainHTML('<div id="root"><div class="testing">Hello World</div></div>')
     })
 
+    it('sets the id', () => {
+      render(<div id="testing">Hello World</div>)
+      expect(root).toContainHTML('<div id="root"><div id="testing">Hello World</div></div>')
+    })
+
     it('sets the style', () => {
       render(<div style={{ background: 'red' }}>Hello World</div>)
       expect(root).toContainHTML('<div id="root"><div style="background: red;">Hello World</div></div>')
@@ -112,6 +117,16 @@ describe('mount', () => {
 
       classNameFacet.set('updated testing')
       expect(root).toContainHTML('<div id="root"><div class="updated testing">Hello World</div></div>')
+    })
+
+    it('sets the id', () => {
+      const idFacet = createFacet({ initialValue: 'testing' })
+
+      render(<fast-div id={idFacet}>Hello World</fast-div>)
+      expect(root).toContainHTML('<div id="root"><div id="testing">Hello World</div></div>')
+
+      idFacet.set('updated testing')
+      expect(root).toContainHTML('<div id="root"><div id="updated testing">Hello World</div></div>')
     })
 
     it('sets the style', () => {
@@ -428,6 +443,26 @@ describe('update', () => {
 
     jest.runAllTimers()
     expect(root).toContainHTML('<div id="root"><div class="hello">Hello World</div></div>')
+  })
+
+  it('updates id', () => {
+    function TestComponent() {
+      const [hello, setHello] = useState(false)
+
+      useEffect(() => {
+        setTimeout(() => {
+          setHello(true)
+        }, 1000)
+      }, [])
+
+      return <div id={hello ? 'hello' : 'goodbye'}>Hello World</div>
+    }
+
+    render(<TestComponent />)
+    expect(root).toContainHTML('<div id="root"><div id="goodbye">Hello World</div></div>')
+
+    jest.runAllTimers()
+    expect(root).toContainHTML('<div id="root"><div id="hello">Hello World</div></div>')
   })
 
   it('updates style', () => {

--- a/packages/@react-facet/dom-fiber/src/setupHostConfig.ts
+++ b/packages/@react-facet/dom-fiber/src/setupHostConfig.ts
@@ -194,6 +194,7 @@ export const setupHostConfig = (): HostConfig<
       children: new Set(),
 
       className: newProps.className != null ? setupClassUpdate(newProps.className, element) : undefined,
+      id: newProps.id != null ? setupIdUpdate(newProps.id, element) : undefined,
       autoPlay: newProps.autoPlay != null ? setupAutoPlayUpdate(newProps.autoPlay, element) : undefined,
       loop: newProps.loop != null ? setupLoopUpdate(newProps.loop, element) : undefined,
       href: newProps.href != null ? setupHrefUpdate(newProps.href, element) : undefined,
@@ -345,6 +346,16 @@ export const setupHostConfig = (): HostConfig<
         element.removeAttribute('data-x-ray')
       } else {
         instance['data-x-ray'] = setupDataXRayUpdate(newProps['data-x-ray'], element)
+      }
+    }
+
+    if (newProps.id !== oldProps.id) {
+      instance.id?.()
+
+      if (newProps.id == null) {
+        element.id = ''
+      } else {
+        instance.id = setupIdUpdate(newProps.id, element)
       }
     }
 
@@ -595,6 +606,7 @@ const cleanupElementContainer = (instance: ElementContainer) => {
   instance['data-droppable']?.()
   instance['data-testid']?.()
   instance['data-x-ray']?.()
+  instance.id?.()
   instance.src?.()
   instance.href?.()
   instance.target?.()
@@ -615,6 +627,16 @@ const setupClassUpdate = (className: FacetProp<string | undefined>, element: HTM
     })
   } else {
     element.className = className ?? ''
+  }
+}
+
+const setupIdUpdate = (id: FacetProp<string | undefined>, element: HTMLElement) => {
+  if (isFacet(id)) {
+    return id.observe((id) => {
+      element.id = id ?? ''
+    })
+  } else {
+    element.id = id ?? ''
   }
 }
 

--- a/packages/@react-facet/dom-fiber/src/types.ts
+++ b/packages/@react-facet/dom-fiber/src/types.ts
@@ -95,6 +95,7 @@ export type ElementProps<T> = PointerEvents &
     ['data-droppable']?: FacetProp<boolean | undefined>
     ['data-testid']?: FacetProp<string | undefined>
     ['data-x-ray']?: FacetProp<boolean | undefined>
+    id?: FacetProp<string | undefined>
     src?: FacetProp<string | undefined>
     href?: FacetProp<string | undefined>
     target?: FacetProp<string | undefined>
@@ -127,6 +128,7 @@ export type ElementContainer = {
   ['data-droppable']?: Unsubscribe
   ['data-testid']?: Unsubscribe
   ['data-x-ray']?: Unsubscribe
+  id?: Unsubscribe
   src?: Unsubscribe
   href?: Unsubscribe
   target?: Unsubscribe


### PR DESCRIPTION
This is so that we can use the `id` attribute with the custom renderer.