### PR TITLE
Add tscompiler paths for our packages

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+		"paths": {
+			"@react-facet/core": ["packages/@react-facet/core/*"],
+			"@react-facet/dom-fiber": ["packages/@react-facet/dom-fiber/*"],
+			"@react-facet/dom-fiber-testing-library": ["packages/@react-facet/dom-fiber-testing-library/*"]
+		},
     "outDir": "dist",
     "target": "es6",
     "moduleResolution": "node",


### PR DESCRIPTION
## Overview
The reason for this change is mainly for making the typescript language server provide us with the correct paths when we want to do automatic imports.

Today, If we do `createFacet(...)` somewhere in our code, it resolves the path like this: `packages/@react-facet/core/src`. After these changes it will instead be resolved like this: `@react-facet/core`. 

I checked the `package.json` dependencies, and only included the packages that the others depend on.