### PR TITLE
Fix contributor image in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The source of the documentation (for contributions) is available at the [documen
         <a href="https://github.com/marlonicus">Marlon Huber-Smith</a>
       </td>
       <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/dderg.png?s=150">
+        <img width="150" height="150"  src="https://github.com/dderg.png?s=150">
         <br>
         <a href="https://github.com/dderg">Danila Dergachev</a>
       </td>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The source of the documentation (for contributions) is available at the [documen
         <a href="https://github.com/marlonicus">Marlon Huber-Smith</a>
       </td>
       <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/prog666.png?s=150">
+        <img width="150" height="150" src="https://github.com/dderg.png?s=150">
         <br>
         <a href="https://github.com/dderg">Danila Dergachev</a>
       </td>


### PR DESCRIPTION
One of the images of the team section in the readme was outdated. This PR updates it to be correct