### PR TITLE
Add keyselector to map component

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: yarn install --immutable
-      - run: cd examples/benchmarking && yarn build && yarn compare listMemoWithKeyFacet listMemoFacet 70
+      - run: cd examples/benchmarking && yarn build && yarn compare listMemoWithKeyFacet listMemoState 70
 
   marker:
     runs-on: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: yarn install --immutable
-      - run: cd examples/benchmarking && yarn build && yarn compare markerWithKeyFacet markerFacet 88 19000
+      - run: cd examples/benchmarking && yarn build && yarn compare markerWithKeyFacet markerState 88 19000
 
   mount:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -12,12 +12,26 @@ jobs:
       - run: yarn install --immutable
       - run: cd examples/benchmarking && yarn build && yarn compare listMemoFacet listMemoState 70
 
+  listMemoWithKey:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: yarn install --immutable
+      - run: cd examples/benchmarking && yarn build && yarn compare listMemoWithKeyFacet listMemoFacet 70
+
   marker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: yarn install --immutable
       - run: cd examples/benchmarking && yarn build && yarn compare markerFacet markerState 88 19000
+
+  markerWithKey:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: yarn install --immutable
+      - run: cd examples/benchmarking && yarn build && yarn compare markerWithKeyFacet markerFacet 88 19000
 
   mount:
     runs-on: ubuntu-latest

--- a/examples/benchmarking/src/listMemoWithKeyFacet.tsx
+++ b/examples/benchmarking/src/listMemoWithKeyFacet.tsx
@@ -1,0 +1,106 @@
+import { useFacetState, Facet, useFacetMap, useFacetEffect, NO_VALUE, MapWithKey } from '@react-facet/core'
+import { render } from '@react-facet/dom-fiber'
+import React, { useEffect } from 'react'
+
+interface Data {
+  name: string
+  health: number
+  index: number
+}
+
+const initialData = Array.from({ length: 2000 }, (_, index): Data => ({ name: 'player', health: 10, index }))
+
+export const Performance = () => {
+  const [dataFacet, setDataFacet] = useFacetState(initialData)
+
+  useEffect(() => {
+    let frameId: number
+
+    const tick = () => {
+      setDataFacet((data) => {
+        if (data == NO_VALUE) return []
+
+        data[0].health = data[0].health === 10 ? 5 : 10
+        return data
+      })
+
+      frameId = requestAnimationFrame(tick)
+    }
+
+    tick()
+
+    return () => {
+      cancelAnimationFrame(frameId)
+    }
+  }, [setDataFacet])
+
+  return (
+    <>
+      <MapWithKey array={dataFacet} equalityCheck={dataEqualityCheck} keySelector={(item) => item.index}>
+        {(item) => <ListItem item={item} />}
+      </MapWithKey>
+    </>
+  )
+}
+
+const ListItem = ({ item }: { item: Facet<Data> }) => {
+  const health = useFacetMap((item) => item.health, [], [item])
+  const name = useFacetMap((item) => item.name, [], [item])
+
+  useFacetEffect(
+    (health) => {
+      randomWork(health)
+    },
+    [],
+    [health],
+  )
+
+  useFacetEffect(
+    (name) => {
+      randomWork(name)
+    },
+    [],
+    [name],
+  )
+
+  useFacetEffect(
+    (name) => {
+      randomWork(name)
+    },
+    [],
+    [name],
+  )
+
+  useFacetEffect(
+    (name) => {
+      randomWork(name)
+    },
+    [],
+    [name],
+  )
+
+  return null
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const randomWork = (name: string | number) => Math.random()
+
+const dataEqualityCheck = () => {
+  let previousName: string
+  let previousHealth: number
+  let previousIndex: number
+
+  return (current: Data) => {
+    if (current.name !== previousName || current.health !== previousHealth || current.index !== previousIndex) {
+      previousName = current.name
+      previousHealth = current.health
+      previousIndex = current.index
+      return false
+    }
+
+    return true
+  }
+}
+
+document.body.innerHTML = '<div id="root"/>'
+render(<Performance />, document.getElementById('root'))

--- a/examples/benchmarking/src/markerWithKeyFacet.tsx
+++ b/examples/benchmarking/src/markerWithKeyFacet.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react'
+import { render } from '@react-facet/dom-fiber'
+import { useFacetState, Facet, useFacetMap, NO_VALUE, MapWithKey } from '@react-facet/core'
+import { times } from 'ramda'
+
+interface Marker {
+  x: number
+  y: number
+}
+
+function Marker({ marker }: { marker: Facet<Marker> }) {
+  const leftValue = useFacetMap(({ x }) => `${x * 1920}px`, [], [marker])
+  const topValue = useFacetMap(({ y }) => `${y * 1080}px`, [], [marker])
+
+  return (
+    <fast-div
+      className={'123'}
+      style={{
+        width: '4rem',
+        height: '4rem',
+        backgroundColor: 'green',
+        position: 'absolute',
+        top: topValue,
+        left: leftValue,
+      }}
+    />
+  )
+}
+
+function Performance() {
+  const [testingFacet, setTestingFacet] = useFacetState(times(() => ({ x: Math.random(), y: Math.random() }), 1000))
+
+  useEffect(() => {
+    let frameId: number
+
+    const update = () => {
+      setTestingFacet((testing) => {
+        if (testing === NO_VALUE) return []
+
+        for (let i = 0; i < testing.length; i++) {
+          testing[i].x = Math.random()
+          testing[i].y = Math.random()
+        }
+
+        return testing
+      })
+
+      frameId = window.requestAnimationFrame(update)
+    }
+
+    update()
+
+    return () => {
+      window.cancelAnimationFrame(frameId)
+    }
+  }, [setTestingFacet])
+
+  return (
+    <div style={{ width: '1920px', height: '1080px', position: 'relative' }}>
+      <MapWithKey array={testingFacet}>{(item, index) => <Marker key={index} marker={item} />}</MapWithKey>
+    </div>
+  )
+}
+
+document.body.innerHTML = '<div id="root"/>'
+render(<Performance />, document.getElementById('root'))

--- a/packages/@react-facet/core/src/components/Map.spec.tsx
+++ b/packages/@react-facet/core/src/components/Map.spec.tsx
@@ -3,299 +3,444 @@ import { act, render } from '@react-facet/dom-fiber-testing-library'
 import { createFacet } from '../facet'
 import { Facet, NoValue } from '../types'
 import { useFacetEffect, useFacetMap } from '../hooks'
-import { Map } from '.'
+import { Map, MapWithKey } from '.'
 
-it('renders all items in a Facet of array', () => {
-  type Input = { key: string; data: string }
-  const data = createFacet<Input[]>({
-    initialValue: [
-      { key: '1', data: 'a' },
-      { key: '2', data: 'b' },
-      { key: '3', data: 'c' },
-      { key: '4', data: 'd' },
-      { key: '5', data: 'e' },
-    ],
+describe('<Map />', () => {
+  it('renders all items in a Facet of array', () => {
+    type Input = { a: string }
+    const data = createFacet({
+      initialValue: [{ a: '1' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }],
+    })
+
+    const ExampleContent = ({ item, index }: { item: Facet<Input>; index: number }) => {
+      return (
+        <span>
+          <fast-text text={useFacetMap(({ a }) => a, [], [item])} />
+          <span>{index}</span>
+        </span>
+      )
+    }
+
+    const inputEqualityCheck = () => {
+      const previous: Partial<Input> = {}
+
+      return (current: Input) => {
+        if (current.a === previous.a) {
+          return true
+        }
+        previous.a = current.a
+        return false
+      }
+    }
+    const Example = () => {
+      return (
+        <Map array={data} equalityCheck={inputEqualityCheck}>
+          {(item, index) => <ExampleContent item={item} index={index} />}
+        </Map>
+      )
+    }
+
+    const scenario = <Example />
+
+    const { container } = render(scenario)
+
+    expect(container).toMatchSnapshot()
   })
 
-  const ExampleContent = ({ item, index }: { item: Facet<Input>; index: number }) => {
-    return (
+  it('unmounts components when the array reduces in size', () => {
+    interface Item {
+      value: string
+    }
+
+    const data = createFacet<Item[]>({
+      initialValue: [{ value: '1' }, { value: '2' }, { value: '3' }, { value: '4' }, { value: '5' }],
+    })
+
+    const Item = ({ item, index }: { item: Facet<Item>; index: number }) => (
+      <span>
+        <fast-text text={useFacetMap(({ value }) => value, [], [item])} />
+        <span>{index}</span>
+      </span>
+    )
+
+    const itemEqualityCheck = () => {
+      const previous: Partial<Item> = {}
+
+      return (current: Item) => {
+        if (current.value === previous.value) {
+          return true
+        }
+
+        previous.value = current.value
+
+        return false
+      }
+    }
+
+    const Example = () => {
+      return (
+        <Map array={data} equalityCheck={itemEqualityCheck}>
+          {(item, index) => <Item item={item} index={index} />}
+        </Map>
+      )
+    }
+
+    const scenario = <Example />
+
+    const { container } = render(scenario)
+
+    expect(container).toMatchSnapshot()
+
+    data.set([{ value: '1' }, { value: '2' }])
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('updates only items that have changed', () => {
+    type Input = { a: string }
+    const data = createFacet({
+      initialValue: [{ a: '1' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }],
+    })
+
+    const mock = jest.fn()
+
+    const ExampleContent = ({ item }: { item: Facet<Input> }) => {
+      useFacetEffect(mock, [], [item])
+      return null
+    }
+
+    const inputEqualityCheck = () => {
+      const previous: Partial<Input> = {}
+
+      return (current: Input) => {
+        if (current.a === previous.a) {
+          return true
+        }
+
+        previous.a = current.a
+
+        return false
+      }
+    }
+
+    const Example = () => {
+      return (
+        <Map array={data} equalityCheck={inputEqualityCheck}>
+          {(item) => <ExampleContent item={item} />}
+        </Map>
+      )
+    }
+
+    const scenario = <Example />
+
+    render(scenario)
+
+    expect(mock).toHaveBeenCalledTimes(5)
+
+    mock.mockClear()
+
+    act(() => {
+      data.set([{ a: '6' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }])
+    })
+
+    expect(mock).toHaveBeenCalledTimes(1)
+    expect(mock).toHaveBeenCalledWith({ a: '6' })
+  })
+})
+
+describe('<MapWithKey />', () => {
+  it('renders all items in a Facet of array', () => {
+    type Input = { key: string; data: string }
+    const data = createFacet<Input[]>({
+      initialValue: [
+        { key: '1', data: 'a' },
+        { key: '2', data: 'b' },
+        { key: '3', data: 'c' },
+        { key: '4', data: 'd' },
+        { key: '5', data: 'e' },
+      ],
+    })
+
+    const ExampleContent = ({ item, index }: { item: Facet<Input>; index: number }) => {
+      return (
+        <span>
+          <fast-text text={useFacetMap(({ data }) => data, [], [item])} />
+          <span>{index}</span>
+        </span>
+      )
+    }
+
+    const keySelector = ({ key }: Input) => key
+
+    const inputEqualityCheck = () => {
+      const previous: Partial<Input> = {}
+
+      return (current: Input) => {
+        if (current.key === previous.key && current.data === previous.data) {
+          return true
+        }
+
+        previous.key = current.key
+        previous.data = current.data
+
+        return false
+      }
+    }
+
+    const Example = () => {
+      return (
+        <MapWithKey array={data} equalityCheck={inputEqualityCheck} keySelector={keySelector}>
+          {(item, index) => <ExampleContent item={item} index={index} />}
+        </MapWithKey>
+      )
+    }
+
+    const scenario = <Example />
+
+    const { container } = render(scenario)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('unmounts components when the array reduces in size', () => {
+    type Input = { key: string; data: string }
+    const data = createFacet<Input[]>({
+      initialValue: [
+        { key: '1', data: 'a' },
+        { key: '2', data: 'b' },
+        { key: '3', data: 'c' },
+        { key: '4', data: 'd' },
+        { key: '5', data: 'e' },
+      ],
+    })
+
+    const Item = ({ item, index }: { item: Facet<Input>; index: number }) => (
       <span>
         <fast-text text={useFacetMap(({ data }) => data, [], [item])} />
         <span>{index}</span>
       </span>
     )
-  }
 
-  const keySelector = ({ key }: Input) => key
+    const keySelector = ({ key }: Input) => key
 
-  const inputEqualityCheck = () => {
-    const previous: Partial<Input> = {}
+    const itemEqualityCheck = () => {
+      const previous: Partial<Input> = {}
 
-    return (current: Input) => {
-      if (current.key === previous.key && current.data === previous.data) {
-        return true
+      return (current: Input) => {
+        if (current.key === previous.key && current.data === previous.data) {
+          return true
+        }
+
+        previous.key = current.key
+        previous.data = current.data
+
+        return false
       }
-
-      previous.key = current.key
-      previous.data = current.data
-
-      return false
     }
-  }
 
-  const Example = () => {
-    return (
-      <Map array={data} equalityCheck={inputEqualityCheck} keySelector={keySelector}>
-        {(item, index) => <ExampleContent item={item} index={index} />}
-      </Map>
-    )
-  }
+    const Example = () => {
+      return (
+        <MapWithKey array={data} equalityCheck={itemEqualityCheck} keySelector={keySelector}>
+          {(item, index) => <Item item={item} index={index} />}
+        </MapWithKey>
+      )
+    }
 
-  const scenario = <Example />
+    const scenario = <Example />
 
-  const { container } = render(scenario)
+    const { container } = render(scenario)
 
-  expect(container).toMatchSnapshot()
-})
+    expect(container).toMatchSnapshot()
 
-it('unmounts components when the array reduces in size', () => {
-  type Input = { key: string; data: string }
-  const data = createFacet<Input[]>({
-    initialValue: [
+    data.set([
       { key: '1', data: 'a' },
       { key: '2', data: 'b' },
-      { key: '3', data: 'c' },
-      { key: '4', data: 'd' },
-      { key: '5', data: 'e' },
-    ],
-  })
-
-  const Item = ({ item, index }: { item: Facet<Input>; index: number }) => (
-    <span>
-      <fast-text text={useFacetMap(({ data }) => data, [], [item])} />
-      <span>{index}</span>
-    </span>
-  )
-
-  const keySelector = ({ key }: Input) => key
-
-  const itemEqualityCheck = () => {
-    const previous: Partial<Input> = {}
-
-    return (current: Input) => {
-      if (current.key === previous.key && current.data === previous.data) {
-        return true
-      }
-
-      previous.key = current.key
-      previous.data = current.data
-
-      return false
-    }
-  }
-
-  const Example = () => {
-    return (
-      <Map array={data} equalityCheck={itemEqualityCheck} keySelector={keySelector}>
-        {(item, index) => <Item item={item} index={index} />}
-      </Map>
-    )
-  }
-
-  const scenario = <Example />
-
-  const { container } = render(scenario)
-
-  expect(container).toMatchSnapshot()
-
-  data.set([
-    { key: '1', data: 'a' },
-    { key: '2', data: 'b' },
-  ])
-
-  expect(container).toMatchSnapshot()
-})
-
-it('updates only items that have changed', () => {
-  type Input = { key: string; data: string }
-  const data = createFacet<Input[]>({
-    initialValue: [
-      { key: '1', data: 'a' },
-      { key: '2', data: 'b' },
-      { key: '3', data: 'c' },
-      { key: '4', data: 'd' },
-      { key: '5', data: 'e' },
-    ],
-  })
-
-  const mock = jest.fn()
-
-  const ExampleContent = ({ item }: { item: Facet<Input> }) => {
-    useFacetEffect(mock, [], [item])
-    return null
-  }
-
-  const keySelector = ({ key }: Input) => key
-
-  const inputEqualityCheck = () => {
-    const previous: Partial<Input> = {}
-
-    return (current: Input) => {
-      if (current.key === previous.key && current.data === previous.data) {
-        return true
-      }
-
-      previous.key = current.key
-      previous.data = current.data
-
-      return false
-    }
-  }
-
-  const Example = () => {
-    return (
-      <Map array={data} equalityCheck={inputEqualityCheck} keySelector={keySelector}>
-        {(item) => <ExampleContent item={item} />}
-      </Map>
-    )
-  }
-
-  const scenario = <Example />
-
-  render(scenario)
-
-  expect(mock).toHaveBeenCalledTimes(5)
-
-  mock.mockClear()
-
-  act(() => {
-    data.set([
-      { key: '1', data: 'z' },
-      { key: '2', data: 'b' },
-      { key: '3', data: 'c' },
-      { key: '4', data: 'd' },
-      { key: '5', data: 'e' },
     ])
+
+    expect(container).toMatchSnapshot()
   })
 
-  expect(mock).toHaveBeenCalledTimes(1)
-  expect(mock).toHaveBeenCalledWith({ key: '1', data: 'z' })
-})
+  it('updates only items that have changed', () => {
+    type Input = { key: string; data: string }
+    const data = createFacet<Input[]>({
+      initialValue: [
+        { key: '1', data: 'a' },
+        { key: '2', data: 'b' },
+        { key: '3', data: 'c' },
+        { key: '4', data: 'd' },
+        { key: '5', data: 'e' },
+      ],
+    })
 
-it('rerenders only when key is updated or added', () => {
-  type Input = { key: string; data: string }
-  const data = createFacet<Input[]>({
-    initialValue: [
-      { key: '1', data: 'a' },
-      { key: '2', data: 'b' },
-      { key: '3', data: 'c' },
-      { key: '4', data: 'd' },
-      { key: '5', data: 'e' },
-    ],
-  })
+    const mock = jest.fn()
 
-  const facetUpdateMock = jest.fn()
-  const onMount = jest.fn()
-
-  const ExampleContent = ({
-    item,
-    index,
-  }: {
-    index: number
-    item: Facet<Input>
-    onMount: (input: Input | NoValue) => void
-  }) => {
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    useEffect(() => onMount(index), [])
-    useFacetEffect((itemValue) => facetUpdateMock(itemValue, index), [index], [item])
-    const dataFacet = useFacetMap(({ data }) => `Data: ${data}`, [], [item])
-    const keyFacet = useFacetMap(({ key }) => `Key: ${key}`, [], [item])
-
-    return (
-      <div>
-        <p>
-          <fast-text text={keyFacet} />
-        </p>
-        <p>
-          <fast-text text={dataFacet} />
-        </p>
-      </div>
-    )
-  }
-
-  const keySelector = ({ key }: Input) => key
-
-  const inputEqualityCheck = () => {
-    const previous: Partial<Input> = {}
-
-    return (current: Input) => {
-      if (current.key === previous.key && current.data === previous.data) {
-        return true
-      }
-
-      previous.key = current.key
-      previous.data = current.data
-
-      return false
+    const ExampleContent = ({ item }: { item: Facet<Input> }) => {
+      useFacetEffect(mock, [], [item])
+      return null
     }
-  }
 
-  const Example = () => {
-    return (
-      <Map array={data} equalityCheck={inputEqualityCheck} keySelector={keySelector}>
-        {(item, index) => <ExampleContent item={item} index={index} onMount={facetUpdateMock} />}
-      </Map>
-    )
-  }
+    const keySelector = ({ key }: Input) => key
 
-  const scenario = <Example />
+    const inputEqualityCheck = () => {
+      const previous: Partial<Input> = {}
 
-  const { container } = render(scenario)
+      return (current: Input) => {
+        if (current.key === previous.key && current.data === previous.data) {
+          return true
+        }
 
-  expect(facetUpdateMock).toHaveBeenCalledTimes(5)
-  expect(onMount).toHaveBeenCalledTimes(5)
+        previous.key = current.key
+        previous.data = current.data
 
-  expect(container).toMatchSnapshot()
+        return false
+      }
+    }
 
-  facetUpdateMock.mockClear()
-  onMount.mockClear()
+    const Example = () => {
+      return (
+        <MapWithKey array={data} equalityCheck={inputEqualityCheck} keySelector={keySelector}>
+          {(item) => <ExampleContent item={item} />}
+        </MapWithKey>
+      )
+    }
 
-  act(() => {
-    data.set([
-      { key: '1', data: 'z' },
-      { key: '2', data: 'b' },
-      { key: '3', data: 'c' },
-      { key: '4', data: 'd' },
-      { key: '5', data: 'e' },
-    ])
+    const scenario = <Example />
+
+    render(scenario)
+
+    expect(mock).toHaveBeenCalledTimes(5)
+
+    mock.mockClear()
+
+    act(() => {
+      data.set([
+        { key: '1', data: 'z' },
+        { key: '2', data: 'b' },
+        { key: '3', data: 'c' },
+        { key: '4', data: 'd' },
+        { key: '5', data: 'e' },
+      ])
+    })
+
+    expect(mock).toHaveBeenCalledTimes(1)
+    expect(mock).toHaveBeenCalledWith({ key: '1', data: 'z' })
   })
 
-  expect(facetUpdateMock).toHaveBeenCalledTimes(1)
-  expect(facetUpdateMock).toHaveBeenCalledWith({ key: '1', data: 'z' }, 0)
-  expect(onMount).not.toHaveBeenCalled()
+  it('rerenders only when key is updated or added', () => {
+    type Input = { key: string; data: string }
+    const data = createFacet<Input[]>({
+      initialValue: [
+        { key: '1', data: 'a' },
+        { key: '2', data: 'b' },
+        { key: '3', data: 'c' },
+        { key: '4', data: 'd' },
+        { key: '5', data: 'e' },
+      ],
+    })
 
-  expect(container).toMatchSnapshot()
+    const facetUpdateMock = jest.fn()
+    const onMount = jest.fn()
 
-  facetUpdateMock.mockClear()
-  onMount.mockClear()
+    const ExampleContent = ({
+      item,
+      index,
+    }: {
+      index: number
+      item: Facet<Input>
+      onMount: (input: Input | NoValue) => void
+    }) => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      useEffect(() => onMount(index), [])
+      useFacetEffect((itemValue) => facetUpdateMock(itemValue, index), [index], [item])
+      const dataFacet = useFacetMap(({ data }) => `Data: ${data}`, [], [item])
+      const keyFacet = useFacetMap(({ key }) => `Key: ${key}`, [], [item])
 
-  act(() => {
-    data.set([
-      { key: '1', data: 'z' },
-      { key: '2', data: 'b' },
-      { key: '3', data: 'c' },
-      { key: '4', data: 'd' },
-      { key: '5', data: 'e' },
-      { key: '6', data: 'f' },
-    ])
+      return (
+        <div>
+          <p>
+            <fast-text text={keyFacet} />
+          </p>
+          <p>
+            <fast-text text={dataFacet} />
+          </p>
+        </div>
+      )
+    }
+
+    const keySelector = ({ key }: Input) => key
+
+    const inputEqualityCheck = () => {
+      const previous: Partial<Input> = {}
+
+      return (current: Input) => {
+        if (current.key === previous.key && current.data === previous.data) {
+          return true
+        }
+
+        previous.key = current.key
+        previous.data = current.data
+
+        return false
+      }
+    }
+
+    const Example = () => {
+      return (
+        <MapWithKey array={data} equalityCheck={inputEqualityCheck} keySelector={keySelector}>
+          {(item, index) => <ExampleContent item={item} index={index} onMount={facetUpdateMock} />}
+        </MapWithKey>
+      )
+    }
+
+    const scenario = <Example />
+
+    const { container } = render(scenario)
+
+    expect(facetUpdateMock).toHaveBeenCalledTimes(5)
+    expect(onMount).toHaveBeenCalledTimes(5)
+
+    expect(container).toMatchSnapshot()
+
+    facetUpdateMock.mockClear()
+    onMount.mockClear()
+
+    act(() => {
+      data.set([
+        { key: '1', data: 'z' },
+        { key: '2', data: 'b' },
+        { key: '3', data: 'c' },
+        { key: '4', data: 'd' },
+        { key: '5', data: 'e' },
+      ])
+    })
+
+    expect(facetUpdateMock).toHaveBeenCalledTimes(1)
+    expect(facetUpdateMock).toHaveBeenCalledWith({ key: '1', data: 'z' }, 0)
+    expect(onMount).not.toHaveBeenCalled()
+
+    expect(container).toMatchSnapshot()
+
+    facetUpdateMock.mockClear()
+    onMount.mockClear()
+
+    act(() => {
+      data.set([
+        { key: '1', data: 'z' },
+        { key: '2', data: 'b' },
+        { key: '3', data: 'c' },
+        { key: '4', data: 'd' },
+        { key: '5', data: 'e' },
+        { key: '6', data: 'f' },
+      ])
+    })
+
+    expect(facetUpdateMock).toHaveBeenCalledTimes(1)
+    expect(facetUpdateMock).toHaveBeenCalledWith({ key: '6', data: 'f' }, 5)
+    expect(onMount).toHaveBeenCalledWith(5)
+
+    expect(container).toMatchSnapshot()
+
+    facetUpdateMock.mockClear()
+    onMount.mockClear()
   })
-
-  expect(facetUpdateMock).toHaveBeenCalledTimes(1)
-  expect(facetUpdateMock).toHaveBeenCalledWith({ key: '6', data: 'f' }, 5)
-  expect(onMount).toHaveBeenCalledWith(5)
-
-  expect(container).toMatchSnapshot()
-
-  facetUpdateMock.mockClear()
-  onMount.mockClear()
 })

--- a/packages/@react-facet/core/src/components/Map.spec.tsx
+++ b/packages/@react-facet/core/src/components/Map.spec.tsx
@@ -6,33 +6,43 @@ import { useFacetEffect, useFacetMap } from '../hooks'
 import { Map } from '.'
 
 it('renders all items in a Facet of array', () => {
-  type Input = { a: string }
-  const data = createFacet({
-    initialValue: [{ a: '1' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }],
+  type Input = { key: string; data: string }
+  const data = createFacet<Input[]>({
+    initialValue: [
+      { key: '1', data: 'a' },
+      { key: '2', data: 'b' },
+      { key: '3', data: 'c' },
+      { key: '4', data: 'd' },
+      { key: '5', data: 'e' },
+    ],
   })
 
   const ExampleContent = ({ item, index }: { item: Facet<Input>; index: number }) => {
     return (
       <span>
-        <fast-text text={useFacetMap(({ a }) => a, [], [item])} />
+        <fast-text text={useFacetMap(({ data }) => data, [], [item])} />
         <span>{index}</span>
       </span>
     )
   }
 
-  const keySelector = ({ a }: Input) => a
+  const keySelector = ({ key }: Input) => key
 
   const inputEqualityCheck = () => {
     const previous: Partial<Input> = {}
 
     return (current: Input) => {
-      if (current.a === previous.a) {
+      if (current.key === previous.key && current.data === previous.data) {
         return true
       }
-      previous.a = current.a
+
+      previous.key = current.key
+      previous.data = current.data
+
       return false
     }
   }
+
   const Example = () => {
     return (
       <Map array={data} equalityCheck={inputEqualityCheck} keySelector={keySelector}>
@@ -49,32 +59,36 @@ it('renders all items in a Facet of array', () => {
 })
 
 it('unmounts components when the array reduces in size', () => {
-  interface Item {
-    value: string
-  }
-
-  const data = createFacet<Item[]>({
-    initialValue: [{ value: '1' }, { value: '2' }, { value: '3' }, { value: '4' }, { value: '5' }],
+  type Input = { key: string; data: string }
+  const data = createFacet<Input[]>({
+    initialValue: [
+      { key: '1', data: 'a' },
+      { key: '2', data: 'b' },
+      { key: '3', data: 'c' },
+      { key: '4', data: 'd' },
+      { key: '5', data: 'e' },
+    ],
   })
 
-  const Item = ({ item, index }: { item: Facet<Item>; index: number }) => (
+  const Item = ({ item, index }: { item: Facet<Input>; index: number }) => (
     <span>
-      <fast-text text={useFacetMap(({ value }) => value, [], [item])} />
+      <fast-text text={useFacetMap(({ data }) => data, [], [item])} />
       <span>{index}</span>
     </span>
   )
 
-  const keySelector = ({ value }: Item) => value
+  const keySelector = ({ key }: Input) => key
 
   const itemEqualityCheck = () => {
-    const previous: Partial<Item> = {}
+    const previous: Partial<Input> = {}
 
-    return (current: Item) => {
-      if (current.value === previous.value) {
+    return (current: Input) => {
+      if (current.key === previous.key && current.data === previous.data) {
         return true
       }
 
-      previous.value = current.value
+      previous.key = current.key
+      previous.data = current.data
 
       return false
     }
@@ -94,15 +108,24 @@ it('unmounts components when the array reduces in size', () => {
 
   expect(container).toMatchSnapshot()
 
-  data.set([{ value: '1' }, { value: '2' }])
+  data.set([
+    { key: '1', data: 'a' },
+    { key: '2', data: 'b' },
+  ])
 
   expect(container).toMatchSnapshot()
 })
 
 it('updates only items that have changed', () => {
-  type Input = { a: string }
-  const data = createFacet({
-    initialValue: [{ a: '1' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }],
+  type Input = { key: string; data: string }
+  const data = createFacet<Input[]>({
+    initialValue: [
+      { key: '1', data: 'a' },
+      { key: '2', data: 'b' },
+      { key: '3', data: 'c' },
+      { key: '4', data: 'd' },
+      { key: '5', data: 'e' },
+    ],
   })
 
   const mock = jest.fn()
@@ -112,17 +135,18 @@ it('updates only items that have changed', () => {
     return null
   }
 
-  const keySelector = ({ a }: Input) => a
+  const keySelector = ({ key }: Input) => key
 
   const inputEqualityCheck = () => {
     const previous: Partial<Input> = {}
 
     return (current: Input) => {
-      if (current.a === previous.a) {
+      if (current.key === previous.key && current.data === previous.data) {
         return true
       }
 
-      previous.a = current.a
+      previous.key = current.key
+      previous.data = current.data
 
       return false
     }
@@ -145,20 +169,33 @@ it('updates only items that have changed', () => {
   mock.mockClear()
 
   act(() => {
-    data.set([{ a: '6' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }])
+    data.set([
+      { key: '1', data: 'z' },
+      { key: '2', data: 'b' },
+      { key: '3', data: 'c' },
+      { key: '4', data: 'd' },
+      { key: '5', data: 'e' },
+    ])
   })
 
   expect(mock).toHaveBeenCalledTimes(1)
-  expect(mock).toHaveBeenCalledWith({ a: '6' })
+  expect(mock).toHaveBeenCalledWith({ key: '1', data: 'z' })
 })
 
-it('mounts children only when a new item is added', () => {
-  type Input = { a: string }
-  const data = createFacet({
-    initialValue: [{ a: '1' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }],
+it('rerenders only when key is updated or added', () => {
+  type Input = { key: string; data: string }
+  const data = createFacet<Input[]>({
+    initialValue: [
+      { key: '1', data: 'a' },
+      { key: '2', data: 'b' },
+      { key: '3', data: 'c' },
+      { key: '4', data: 'd' },
+      { key: '5', data: 'e' },
+    ],
   })
 
   const facetUpdateMock = jest.fn()
+  const onMount = jest.fn()
 
   const ExampleContent = ({
     item,
@@ -168,21 +205,36 @@ it('mounts children only when a new item is added', () => {
     item: Facet<Input>
     onMount: (input: Input | NoValue) => void
   }) => {
-    useFacetEffect((itemValue) => console.log(itemValue, index) || facetUpdateMock(itemValue, index), [index], [item])
-    return null
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => onMount(index), [])
+    useFacetEffect((itemValue) => facetUpdateMock(itemValue, index), [index], [item])
+    const dataFacet = useFacetMap(({ data }) => `Data: ${data}`, [], [item])
+    const keyFacet = useFacetMap(({ key }) => `Key: ${key}`, [], [item])
+
+    return (
+      <div>
+        <p>
+          <fast-text text={keyFacet} />
+        </p>
+        <p>
+          <fast-text text={dataFacet} />
+        </p>
+      </div>
+    )
   }
 
-  const keySelector = ({ a }: Input) => a
+  const keySelector = ({ key }: Input) => key
 
   const inputEqualityCheck = () => {
     const previous: Partial<Input> = {}
 
     return (current: Input) => {
-      if (current.a === previous.a) {
+      if (current.key === previous.key && current.data === previous.data) {
         return true
       }
 
-      previous.a = current.a
+      previous.key = current.key
+      previous.data = current.data
 
       return false
     }
@@ -198,39 +250,52 @@ it('mounts children only when a new item is added', () => {
 
   const scenario = <Example />
 
-  console.log('Render 1')
-  render(scenario)
+  const { container } = render(scenario)
 
   expect(facetUpdateMock).toHaveBeenCalledTimes(5)
+  expect(onMount).toHaveBeenCalledTimes(5)
+
+  expect(container).toMatchSnapshot()
 
   facetUpdateMock.mockClear()
+  onMount.mockClear()
 
-  console.log('Render 2')
   act(() => {
-    data.set([{ a: '0' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }])
+    data.set([
+      { key: '1', data: 'z' },
+      { key: '2', data: 'b' },
+      { key: '3', data: 'c' },
+      { key: '4', data: 'd' },
+      { key: '5', data: 'e' },
+    ])
   })
 
   expect(facetUpdateMock).toHaveBeenCalledTimes(1)
-  expect(facetUpdateMock).toHaveBeenCalledWith({ a: '0' }, 0)
+  expect(facetUpdateMock).toHaveBeenCalledWith({ key: '1', data: 'z' }, 0)
+  expect(onMount).not.toHaveBeenCalled()
+
+  expect(container).toMatchSnapshot()
 
   facetUpdateMock.mockClear()
+  onMount.mockClear()
 
-  console.log('Render 3')
   act(() => {
-    data.set([{ a: '0' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }, { a: '6' }])
+    data.set([
+      { key: '1', data: 'z' },
+      { key: '2', data: 'b' },
+      { key: '3', data: 'c' },
+      { key: '4', data: 'd' },
+      { key: '5', data: 'e' },
+      { key: '6', data: 'f' },
+    ])
   })
 
   expect(facetUpdateMock).toHaveBeenCalledTimes(1)
-  expect(facetUpdateMock).toHaveBeenCalledWith({ a: '6' }, 5)
+  expect(facetUpdateMock).toHaveBeenCalledWith({ key: '6', data: 'f' }, 5)
+  expect(onMount).toHaveBeenCalledWith(5)
+
+  expect(container).toMatchSnapshot()
 
   facetUpdateMock.mockClear()
-
-  // act(() => {
-  //   data.set([{ a: '0' }, { a: '2' }, { a: '3' }, { a: '4' }, { a: '5' }, { a: '6' }])
-  // })
-
-  // expect(facetUpdateMock).toHaveBeenCalledTimes(1)
-  // expect(facetUpdateMock).toHaveBeenCalledWith({ a: '0' }, 0)
-
-  // facetUpdateMock.mockClear()
+  onMount.mockClear()
 })

--- a/packages/@react-facet/core/src/components/Map.tsx
+++ b/packages/@react-facet/core/src/components/Map.tsx
@@ -1,45 +1,49 @@
-import React, { ReactElement } from 'react'
-import { useFacetMap, useFacetMemo, useFacetUnwrap } from '../hooks'
-import { EqualityCheck, Facet, NO_VALUE } from '../types'
+import React, { ReactElement, useMemo, useEffect } from 'react'
+import { useFacetMap, useFacetUnwrap, useFacetMemo, useFacetWrap } from '../hooks'
+import { EqualityCheck, Facet, NO_VALUE, FacetProp } from '../types'
+import { createFacet } from '../facet'
 
 export type MapProps<T> = {
-  array: Facet<T[]>
   children: (item: Facet<T>, index: number) => ReactElement
+  array: Facet<T[]>
+  keySelector?: (item: T) => string
   equalityCheck?: EqualityCheck<T>
 }
 
-export const Map = <T,>({ array, children, equalityCheck }: MapProps<T>) => {
-  const countValue = useFacetUnwrap(useFacetMap((array) => array.length, [], [array])) ?? 0
+export const Map = <T,>({ array, children, equalityCheck, keySelector }: MapProps<T>) => {
+  const arrayLength = useFacetUnwrap(useFacetMap((array) => array.length, [], [array]))
+  const arrayUnwrapped = array.get()
+
+  if (arrayLength === NO_VALUE || arrayUnwrapped == NO_VALUE) return null
 
   return (
     <>
-      {times(
-        (index) =>
-          equalityCheck != null ? (
-            <MapChildMemo<T>
-              key={index}
-              arrayFacet={array}
-              index={index}
-              equalityCheck={equalityCheck}
-              children={children}
-            />
-          ) : (
-            <MapChild<T> key={index} arrayFacet={array} index={index} children={children} />
-          ),
-        countValue !== NO_VALUE ? countValue : 0,
-      )}
+      {arrayUnwrapped.map((item, index) => {
+        const key = keySelector?.(item) ?? index
+        return (
+          <Child<T>
+            arrayFacet={array}
+            key={key}
+            index={index}
+            item={item}
+            children={children}
+            equalityCheck={equalityCheck}
+          />
+        )
+      })}
     </>
   )
 }
 
-type MapChildMemoProps<T> = {
+type ChildProps<T> = {
   arrayFacet: Facet<T[]>
+  item: T
   index: number
   children: (item: Facet<T>, index: number) => ReactElement
-  equalityCheck: EqualityCheck<T>
+  equalityCheck?: EqualityCheck<T>
 }
 
-const MapChildMemo = <T,>({ arrayFacet, index, children, equalityCheck }: MapChildMemoProps<T>) => {
+const Child = <T,>({ arrayFacet, children, index, equalityCheck }: ChildProps<T>) => {
   const childFacet = useFacetMemo(
     (array) => {
       if (index < array.length) return array[index]
@@ -49,38 +53,6 @@ const MapChildMemo = <T,>({ arrayFacet, index, children, equalityCheck }: MapChi
     [arrayFacet],
     equalityCheck,
   )
-  return children(childFacet, index)
-}
-
-type MapChildProps<T> = {
-  arrayFacet: Facet<T[]>
-  index: number
-  children: (item: Facet<T>, index: number) => ReactElement
-}
-
-const MapChild = <T,>({ arrayFacet, index, children }: MapChildProps<T>) => {
-  const childFacet = useFacetMap(
-    (array) => {
-      if (index < array.length) return array[index]
-      return NO_VALUE
-    },
-    [index],
-    [arrayFacet],
-  )
 
   return children(childFacet, index)
-}
-
-interface TimesFn<T> {
-  (index: number): T
-}
-
-const times = <T,>(fn: TimesFn<T>, n: number) => {
-  const result = []
-
-  for (let index = 0; index < n; index++) {
-    result.push(fn(index))
-  }
-
-  return result
 }

--- a/packages/@react-facet/core/src/components/Map.tsx
+++ b/packages/@react-facet/core/src/components/Map.tsx
@@ -1,15 +1,93 @@
 import React, { ReactElement } from 'react'
-import { useFacetMap, useFacetUnwrap, useFacetMemo } from '../hooks'
+import { useFacetMap, useFacetMemo, useFacetUnwrap } from '../hooks'
 import { EqualityCheck, Facet, NO_VALUE } from '../types'
 
 export type MapProps<T> = {
-  children: (item: Facet<T>, index: number) => ReactElement
   array: Facet<T[]>
-  keySelector?: (item: T) => string
+  children: (item: Facet<T>, index: number) => ReactElement
   equalityCheck?: EqualityCheck<T>
 }
 
-export const Map = <T,>({ array, children, equalityCheck, keySelector }: MapProps<T>) => {
+export const Map = <T,>({ array, children, equalityCheck }: MapProps<T>) => {
+  const countValue = useFacetUnwrap(useFacetMap((array) => array.length, [], [array])) ?? 0
+
+  return (
+    <>
+      {times(
+        (index) =>
+          equalityCheck != null ? (
+            <MapChildMemo<T>
+              key={index}
+              arrayFacet={array}
+              index={index}
+              equalityCheck={equalityCheck}
+              children={children}
+            />
+          ) : (
+            <MapChild<T> key={index} arrayFacet={array} index={index} children={children} />
+          ),
+        countValue !== NO_VALUE ? countValue : 0,
+      )}
+    </>
+  )
+}
+
+type MapChildMemoProps<T> = {
+  arrayFacet: Facet<T[]>
+  index: number
+  children: (item: Facet<T>, index: number) => ReactElement
+  equalityCheck: EqualityCheck<T>
+}
+
+const MapChildMemo = <T,>({ arrayFacet, index, children, equalityCheck }: MapChildMemoProps<T>) => {
+  const childFacet = useFacetMemo(
+    (array) => {
+      if (index < array.length) return array[index]
+      return NO_VALUE
+    },
+    [index],
+    [arrayFacet],
+    equalityCheck,
+  )
+  return children(childFacet, index)
+}
+
+type MapChildProps<T> = {
+  arrayFacet: Facet<T[]>
+  index: number
+  children: (item: Facet<T>, index: number) => ReactElement
+}
+
+const MapChild = <T,>({ arrayFacet, index, children }: MapChildProps<T>) => {
+  const childFacet = useFacetMap(
+    (array) => {
+      if (index < array.length) return array[index]
+      return NO_VALUE
+    },
+    [index],
+    [arrayFacet],
+  )
+
+  return children(childFacet, index)
+}
+
+interface TimesFn<T> {
+  (index: number): T
+}
+
+const times = <T,>(fn: TimesFn<T>, n: number) => {
+  const result = []
+
+  for (let index = 0; index < n; index++) {
+    result.push(fn(index))
+  }
+
+  return result
+}
+
+export type MapWithKeyProps<T> = MapProps<T> & { keySelector?: (item: T) => React.Key }
+
+export const MapWithKey = <T,>({ array, children, equalityCheck, keySelector }: MapWithKeyProps<T>) => {
   const arrayLength = useFacetUnwrap(useFacetMap((array) => array.length, [], [array]))
   const arrayUnwrapped = array.get()
 
@@ -21,7 +99,7 @@ export const Map = <T,>({ array, children, equalityCheck, keySelector }: MapProp
         const key = keySelector?.(item) ?? index
 
         return (
-          <Child<T>
+          <MapWithKeyChild<T>
             arrayFacet={array}
             key={key}
             index={index}
@@ -34,8 +112,7 @@ export const Map = <T,>({ array, children, equalityCheck, keySelector }: MapProp
     </>
   )
 }
-
-type ChildProps<T> = {
+type MapWithKeyChildProps<T> = {
   arrayFacet: Facet<T[]>
   item: T
   index: number
@@ -43,7 +120,7 @@ type ChildProps<T> = {
   equalityCheck?: EqualityCheck<T>
 }
 
-const Child = <T,>({ arrayFacet, children, index, equalityCheck }: ChildProps<T>) => {
+const MapWithKeyChild = <T,>({ arrayFacet, children, index, equalityCheck }: MapWithKeyChildProps<T>) => {
   const childFacet = useFacetMemo(
     (array) => {
       if (index < array.length) return array[index]

--- a/packages/@react-facet/core/src/components/Map.tsx
+++ b/packages/@react-facet/core/src/components/Map.tsx
@@ -1,7 +1,6 @@
-import React, { ReactElement, useMemo, useEffect } from 'react'
-import { useFacetMap, useFacetUnwrap, useFacetMemo, useFacetWrap } from '../hooks'
-import { EqualityCheck, Facet, NO_VALUE, FacetProp } from '../types'
-import { createFacet } from '../facet'
+import React, { ReactElement } from 'react'
+import { useFacetMap, useFacetUnwrap, useFacetMemo } from '../hooks'
+import { EqualityCheck, Facet, NO_VALUE } from '../types'
 
 export type MapProps<T> = {
   children: (item: Facet<T>, index: number) => ReactElement
@@ -20,6 +19,7 @@ export const Map = <T,>({ array, children, equalityCheck, keySelector }: MapProp
     <>
       {arrayUnwrapped.map((item, index) => {
         const key = keySelector?.(item) ?? index
+
         return (
           <Child<T>
             arrayFacet={array}

--- a/packages/@react-facet/core/src/components/__snapshots__/Map.spec.tsx.snap
+++ b/packages/@react-facet/core/src/components/__snapshots__/Map.spec.tsx.snap
@@ -3,31 +3,31 @@
 exports[`renders all items in a Facet of array 1`] = `
 <div>
   <span>
-    1
+    a
     <span>
       0
     </span>
   </span>
   <span>
-    2
+    b
     <span>
       1
     </span>
   </span>
   <span>
-    3
+    c
     <span>
       2
     </span>
   </span>
   <span>
-    4
+    d
     <span>
       3
     </span>
   </span>
   <span>
-    5
+    e
     <span>
       4
     </span>
@@ -35,34 +35,177 @@ exports[`renders all items in a Facet of array 1`] = `
 </div>
 `;
 
+exports[`rerenders only when key is updated or added 1`] = `
+<div>
+  <div>
+    <p>
+      Key: 1
+    </p>
+    <p>
+      Data: a
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 2
+    </p>
+    <p>
+      Data: b
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 3
+    </p>
+    <p>
+      Data: c
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 4
+    </p>
+    <p>
+      Data: d
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 5
+    </p>
+    <p>
+      Data: e
+    </p>
+  </div>
+</div>
+`;
+
+exports[`rerenders only when key is updated or added 2`] = `
+<div>
+  <div>
+    <p>
+      Key: 1
+    </p>
+    <p>
+      Data: z
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 2
+    </p>
+    <p>
+      Data: b
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 3
+    </p>
+    <p>
+      Data: c
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 4
+    </p>
+    <p>
+      Data: d
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 5
+    </p>
+    <p>
+      Data: e
+    </p>
+  </div>
+</div>
+`;
+
+exports[`rerenders only when key is updated or added 3`] = `
+<div>
+  <div>
+    <p>
+      Key: 1
+    </p>
+    <p>
+      Data: z
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 2
+    </p>
+    <p>
+      Data: b
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 3
+    </p>
+    <p>
+      Data: c
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 4
+    </p>
+    <p>
+      Data: d
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 5
+    </p>
+    <p>
+      Data: e
+    </p>
+  </div>
+  <div>
+    <p>
+      Key: 6
+    </p>
+    <p>
+      Data: f
+    </p>
+  </div>
+</div>
+`;
+
 exports[`unmounts components when the array reduces in size 1`] = `
 <div>
   <span>
-    1
+    a
     <span>
       0
     </span>
   </span>
   <span>
-    2
+    b
     <span>
       1
     </span>
   </span>
   <span>
-    3
+    c
     <span>
       2
     </span>
   </span>
   <span>
-    4
+    d
     <span>
       3
     </span>
   </span>
   <span>
-    5
+    e
     <span>
       4
     </span>
@@ -73,13 +216,13 @@ exports[`unmounts components when the array reduces in size 1`] = `
 exports[`unmounts components when the array reduces in size 2`] = `
 <div>
   <span>
-    1
+    a
     <span>
       0
     </span>
   </span>
   <span>
-    2
+    b
     <span>
       1
     </span>

--- a/packages/@react-facet/core/src/components/__snapshots__/Map.spec.tsx.snap
+++ b/packages/@react-facet/core/src/components/__snapshots__/Map.spec.tsx.snap
@@ -1,6 +1,93 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders all items in a Facet of array 1`] = `
+exports[`<Map /> renders all items in a Facet of array 1`] = `
+<div>
+  <span>
+    1
+    <span>
+      0
+    </span>
+  </span>
+  <span>
+    2
+    <span>
+      1
+    </span>
+  </span>
+  <span>
+    3
+    <span>
+      2
+    </span>
+  </span>
+  <span>
+    4
+    <span>
+      3
+    </span>
+  </span>
+  <span>
+    5
+    <span>
+      4
+    </span>
+  </span>
+</div>
+`;
+
+exports[`<Map /> unmounts components when the array reduces in size 1`] = `
+<div>
+  <span>
+    1
+    <span>
+      0
+    </span>
+  </span>
+  <span>
+    2
+    <span>
+      1
+    </span>
+  </span>
+  <span>
+    3
+    <span>
+      2
+    </span>
+  </span>
+  <span>
+    4
+    <span>
+      3
+    </span>
+  </span>
+  <span>
+    5
+    <span>
+      4
+    </span>
+  </span>
+</div>
+`;
+
+exports[`<Map /> unmounts components when the array reduces in size 2`] = `
+<div>
+  <span>
+    1
+    <span>
+      0
+    </span>
+  </span>
+  <span>
+    2
+    <span>
+      1
+    </span>
+  </span>
+</div>
+`;
+
+exports[`<MapWithKey /> renders all items in a Facet of array 1`] = `
 <div>
   <span>
     a
@@ -35,7 +122,7 @@ exports[`renders all items in a Facet of array 1`] = `
 </div>
 `;
 
-exports[`rerenders only when key is updated or added 1`] = `
+exports[`<MapWithKey /> rerenders only when key is updated or added 1`] = `
 <div>
   <div>
     <p>
@@ -80,7 +167,7 @@ exports[`rerenders only when key is updated or added 1`] = `
 </div>
 `;
 
-exports[`rerenders only when key is updated or added 2`] = `
+exports[`<MapWithKey /> rerenders only when key is updated or added 2`] = `
 <div>
   <div>
     <p>
@@ -125,7 +212,7 @@ exports[`rerenders only when key is updated or added 2`] = `
 </div>
 `;
 
-exports[`rerenders only when key is updated or added 3`] = `
+exports[`<MapWithKey /> rerenders only when key is updated or added 3`] = `
 <div>
   <div>
     <p>
@@ -178,7 +265,7 @@ exports[`rerenders only when key is updated or added 3`] = `
 </div>
 `;
 
-exports[`unmounts components when the array reduces in size 1`] = `
+exports[`<MapWithKey /> unmounts components when the array reduces in size 1`] = `
 <div>
   <span>
     a
@@ -213,7 +300,7 @@ exports[`unmounts components when the array reduces in size 1`] = `
 </div>
 `;
 
-exports[`unmounts components when the array reduces in size 2`] = `
+exports[`<MapWithKey /> unmounts components when the array reduces in size 2`] = `
 <div>
   <span>
     a


### PR DESCRIPTION
Today the `<Map />` component is internally using the array index as a `key` when rendering out each item. This causes a similar problem to what is discussed in the [official React docs](https://reactjs.org/docs/lists-and-keys.html#keys). This PR introduces a prop called `keySelector`, which enables the consumer to select a unique key from the item data. If no `keySelector` is provided we default back to index as `key`. 

In this PR we kept both implementations to be able to do a side-by-side comparison of the Map component: `<Map />` (old) and `<MapWithKey />` (new)

# Benchmarking
- [Relative performance listMemoFacet/listMemoState: 48.98](https://github.com/Mojang/ore-ui/runs/6003102521?check_suite_focus=true#step:4:32)
- [Relative performance listMemoWithKeyFacet/listMemoState: 49.40](https://github.com/Mojang/ore-ui/runs/6003102888?check_suite_focus=true#step:4:32)
- [Relative performance markerFacet/markerState: 86.08](https://github.com/Mojang/ore-ui/runs/6003102764?check_suite_focus=true#step:4:32)
- [Relative performance markerWithKeyFacet/markerState: 88.94](https://github.com/Mojang/ore-ui/runs/6003103037?check_suite_focus=true#step:4:32)

The new implementation seems to be somewhat less performant (2-3%), but the benchmarking results vary between runs.


# Discussion
- Should the `keySelector` prop be mandatory or optional? The best practice is not to use the array index as a key, but making it mandatory would be a breaking change
- Since this is a bug that only appears when adding/removing items that are not at end of the array (not that common use case), should we have two implementations? One where the array length is static (ie. could use the index as a key) and one dynamic
