### PR TITLE
Add support for onScroll event listeners

### DIFF
--- a/packages/@react-facet/dom-components/src/Div.tsx
+++ b/packages/@react-facet/dom-components/src/Div.tsx
@@ -1,12 +1,13 @@
 import React, { useRef, RefObject, ReactNode } from 'react'
 import { FacetCSSStyleDeclaration, FacetProp } from '@react-facet/core'
-import { FocusEvents, KeyboardEvents, PointerEvents } from './types'
+import { FocusEvents, KeyboardEvents, PointerEvents, ScrollingEvents } from './types'
 import { useSetProp } from './useSetProp'
 import { useSetStyle } from './useSetStyle'
 
 export type DivProps = PointerEvents<HTMLDivElement> &
   KeyboardEvents<HTMLDivElement> &
-  FocusEvents<HTMLSpanElement> & {
+  FocusEvents<HTMLSpanElement> &
+  ScrollingEvents & {
     className?: FacetProp<string | undefined>
     id?: FacetProp<string | undefined>
     style?: FacetCSSStyleDeclaration

--- a/packages/@react-facet/dom-components/src/Img.tsx
+++ b/packages/@react-facet/dom-components/src/Img.tsx
@@ -1,16 +1,17 @@
 import React, { RefObject, useRef } from 'react'
 import { FacetCSSStyleDeclaration, FacetProp } from '@react-facet/core'
-import { PointerEvents } from './types'
+import { PointerEvents, ScrollingEvents } from './types'
 import { useSetProp } from './useSetProp'
 import { useSetStyle } from './useSetStyle'
 
-export interface ImgProps extends PointerEvents<HTMLImageElement> {
+export type ImgProps = {
   className?: FacetProp<string | undefined>
   id?: FacetProp<string | undefined>
   style?: FacetCSSStyleDeclaration
   src: FacetProp<string | undefined>
   innerRef?: RefObject<HTMLImageElement>
-}
+} & PointerEvents<HTMLImageElement> &
+  ScrollingEvents
 
 export const Img = ({ style, className, id, src, innerRef, ...handlers }: ImgProps) => {
   const defaultRef = useRef<HTMLImageElement>(null)

--- a/packages/@react-facet/dom-components/src/Input.tsx
+++ b/packages/@react-facet/dom-components/src/Input.tsx
@@ -2,7 +2,7 @@ import React, { useRef, RefObject } from 'react'
 import { FacetCSSStyleDeclaration, FacetProp } from '@react-facet/core'
 import { useSetProp } from './useSetProp'
 import { useSetStyle } from './useSetStyle'
-import { PointerEvents, FocusEvents, KeyboardEvents } from './types'
+import { PointerEvents, FocusEvents, KeyboardEvents, ScrollingEvents } from './types'
 
 export type InputType = 'text' | 'button' | 'password' | 'checkbox' | 'radio' | 'number'
 
@@ -17,7 +17,8 @@ export type InputProps = {
   innerRef?: RefObject<HTMLInputElement>
 } & FocusEvents<HTMLInputElement> &
   KeyboardEvents<HTMLInputElement> &
-  PointerEvents<HTMLInputElement>
+  PointerEvents<HTMLInputElement> &
+  ScrollingEvents
 
 export const Input = ({
   style,

--- a/packages/@react-facet/dom-components/src/Paragraph.tsx
+++ b/packages/@react-facet/dom-components/src/Paragraph.tsx
@@ -4,13 +4,13 @@ import { PointerEvents } from './types'
 import { useSetProp } from './useSetProp'
 import { useSetStyle } from './useSetStyle'
 
-export interface ParagraphProps extends PointerEvents<HTMLParagraphElement> {
+export type ParagraphProps = {
   className?: FacetProp<string | undefined>
   id?: FacetProp<string | undefined>
   style?: FacetCSSStyleDeclaration
   children?: ReactNode
   innerRef?: RefObject<HTMLParagraphElement>
-}
+} & PointerEvents<HTMLParagraphElement>
 
 export const Paragraph = ({ style, className, children, id, innerRef, ...handlers }: ParagraphProps) => {
   const defaultRef = useRef<HTMLParagraphElement>(null)

--- a/packages/@react-facet/dom-components/src/TextArea.tsx
+++ b/packages/@react-facet/dom-components/src/TextArea.tsx
@@ -2,7 +2,7 @@ import React, { useRef, RefObject } from 'react'
 import { FacetCSSStyleDeclaration, FacetProp } from '@react-facet/core'
 import { useSetProp } from './useSetProp'
 import { useSetStyle } from './useSetStyle'
-import { PointerEvents, FocusEvents, KeyboardEvents } from './types'
+import { PointerEvents, FocusEvents, KeyboardEvents, ScrollingEvents } from './types'
 
 export type TextAreaProps = {
   className?: FacetProp<string | undefined>
@@ -15,7 +15,8 @@ export type TextAreaProps = {
   innerRef?: RefObject<HTMLTextAreaElement>
 } & FocusEvents<HTMLTextAreaElement> &
   KeyboardEvents<HTMLTextAreaElement> &
-  PointerEvents<HTMLTextAreaElement>
+  PointerEvents<HTMLTextAreaElement> &
+  ScrollingEvents
 
 export const TextArea = ({
   style,

--- a/packages/@react-facet/dom-components/src/types.ts
+++ b/packages/@react-facet/dom-components/src/types.ts
@@ -3,6 +3,7 @@ import React from 'react'
 export type FocusCallback<T> = (e: React.FocusEvent<T>) => void
 export type TouchCallback<T> = (e: React.TouchEvent<T>) => void
 export type MouseCallback<T> = (event: React.MouseEvent<T>) => void
+export type ScrollCallback = (e: React.UIEvent) => void
 
 export interface PointerEvents<T> {
   onClick?: MouseCallback<T>
@@ -26,4 +27,8 @@ export interface KeyboardEvents<T> {
   onKeyPress?: KeyboardCallback<T>
   onKeyDown?: KeyboardCallback<T>
   onKeyUp?: KeyboardCallback<T>
+}
+
+export interface ScrollingEvents {
+  onScroll?: ScrollCallback
 }

--- a/packages/@react-facet/dom-fiber/src/setupHostConfig.spec.tsx
+++ b/packages/@react-facet/dom-fiber/src/setupHostConfig.spec.tsx
@@ -295,6 +295,7 @@ describe('mount', () => {
     let onKeyPress: jest.Mock
     let onKeyDown: jest.Mock
     let onKeyUp: jest.Mock
+    let onScroll: jest.Mock
     let div: Element
 
     beforeEach(() => {
@@ -311,6 +312,7 @@ describe('mount', () => {
       onKeyPress = jest.fn()
       onKeyDown = jest.fn()
       onKeyUp = jest.fn()
+      onScroll = jest.fn()
 
       render(
         <div
@@ -328,6 +330,7 @@ describe('mount', () => {
           onKeyPress={onKeyPress}
           onKeyDown={onKeyDown}
           onKeyUp={onKeyUp}
+          onScroll={onScroll}
         >
           Hello World
         </div>,
@@ -400,6 +403,11 @@ describe('mount', () => {
     it('supports onKeyUp', () => {
       div.dispatchEvent(new Event('keyup'))
       expect(onKeyUp).toHaveBeenCalled()
+    })
+
+    it('supports onScroll', () => {
+      div.dispatchEvent(new Event('scroll'))
+      expect(onScroll).toHaveBeenCalled()
     })
   })
 })
@@ -669,6 +677,7 @@ describe('update', () => {
     let firstOnKeyPress: jest.Mock
     let firstOnKeyDown: jest.Mock
     let firstOnKeyUp: jest.Mock
+    let firstOnScroll: jest.Mock
 
     let secondOnClick: jest.Mock
     let secondOnFocus: jest.Mock
@@ -683,6 +692,7 @@ describe('update', () => {
     let secondOnKeyPress: jest.Mock
     let secondOnKeyDown: jest.Mock
     let secondOnKeyUp: jest.Mock
+    let secondOnScroll: jest.Mock
 
     let div: Element
 
@@ -711,6 +721,7 @@ describe('update', () => {
           onKeyPress={second ? secondOnKeyPress : firstOnKeyPress}
           onKeyDown={second ? secondOnKeyDown : firstOnKeyDown}
           onKeyUp={second ? secondOnKeyUp : firstOnKeyUp}
+          onScroll={second ? secondOnScroll : firstOnScroll}
         >
           Hello World
         </div>
@@ -731,6 +742,7 @@ describe('update', () => {
       firstOnKeyPress = jest.fn()
       firstOnKeyDown = jest.fn()
       firstOnKeyUp = jest.fn()
+      firstOnScroll = jest.fn()
 
       secondOnClick = jest.fn()
       secondOnFocus = jest.fn()
@@ -745,6 +757,7 @@ describe('update', () => {
       secondOnKeyPress = jest.fn()
       secondOnKeyDown = jest.fn()
       secondOnKeyUp = jest.fn()
+      secondOnScroll = jest.fn()
 
       render(<TestComponent />)
 
@@ -932,6 +945,20 @@ describe('update', () => {
       div.dispatchEvent(new Event('keyup'))
       expect(firstOnKeyUp).not.toHaveBeenCalled()
       expect(secondOnKeyUp).toHaveBeenCalled()
+    })
+
+    it('supports onScroll', () => {
+      div.dispatchEvent(new Event('scroll'))
+      expect(firstOnScroll).toHaveBeenCalled()
+      expect(secondOnScroll).not.toHaveBeenCalled()
+
+      firstOnScroll.mockClear()
+      secondOnScroll.mockClear()
+      jest.runAllTimers()
+
+      div.dispatchEvent(new Event('scroll'))
+      expect(firstOnScroll).not.toHaveBeenCalled()
+      expect(secondOnScroll).toHaveBeenCalled()
     })
   })
 })

--- a/packages/@react-facet/dom-fiber/src/setupHostConfig.ts
+++ b/packages/@react-facet/dom-fiber/src/setupHostConfig.ts
@@ -187,6 +187,10 @@ export const setupHostConfig = (): HostConfig<
       element.addEventListener('keyup', newProps.onKeyUp as EventListener)
     }
 
+    if (newProps.onScroll) {
+      element.addEventListener('scroll', newProps.onScroll as EventListener)
+    }
+
     return {
       element,
       styleUnsubscribers,
@@ -527,6 +531,11 @@ export const setupHostConfig = (): HostConfig<
     if (newProps.onKeyUp !== oldProps.onKeyUp) {
       if (oldProps.onKeyUp) element.removeEventListener('keyup', oldProps.onKeyUp)
       if (newProps.onKeyUp) element.addEventListener('keyup', newProps.onKeyUp)
+    }
+
+    if (newProps.onScroll !== oldProps.onScroll) {
+      if (oldProps.onScroll) element.removeEventListener('scroll', oldProps.onScroll)
+      if (newProps.onScroll) element.addEventListener('scroll', newProps.onScroll)
     }
   },
 

--- a/packages/@react-facet/dom-fiber/src/types.ts
+++ b/packages/@react-facet/dom-fiber/src/types.ts
@@ -37,7 +37,8 @@ export interface NoTimeout {
 
 export type FocusCallback = (e: FocusEvent) => void
 export type TouchCallback = (e: TouchEvent) => void
-export type MouseCallback = (event: MouseEvent) => void
+export type MouseCallback = (e: MouseEvent) => void
+export type ScrollCallback = (e: Event) => void
 
 export interface PointerEvents {
   onClick?: MouseCallback
@@ -63,6 +64,10 @@ export interface KeyboardEvents {
   onKeyUp?: KeyboardCallback
 }
 
+export interface ScrollingEvents {
+  onScroll?: ScrollCallback
+}
+
 interface StrictReactElement<P = unknown, T extends string = string> {
   type: T
   props: P
@@ -78,7 +83,8 @@ export type StrictReactNode = StrictReactElement | ReactText | Array<StrictReact
 
 export type ElementProps<T> = PointerEvents &
   FocusEvents &
-  KeyboardEvents & {
+  KeyboardEvents &
+  ScrollingEvents & {
     key?: string | number
 
     /**

--- a/packages/@react-facet/dom-fiber/src/types.ts
+++ b/packages/@react-facet/dom-fiber/src/types.ts
@@ -38,7 +38,7 @@ export interface NoTimeout {
 export type FocusCallback = (e: FocusEvent) => void
 export type TouchCallback = (e: TouchEvent) => void
 export type MouseCallback = (e: MouseEvent) => void
-export type ScrollCallback = (e: Event) => void
+export type ScrollCallback = (e: UIEvent) => void
 
 export interface PointerEvents {
   onClick?: MouseCallback


### PR DESCRIPTION
This PR extends both `@react-facet/dom-fiber` and `@react-facet/dom-components` to add support for the `onScroll` events. In the past this wasn't supported by Gameface, but I've checked it recently and it now works.