### PR TITLE
Default line endings for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 /.yarn/** linguist-vendored
+* text=auto


### PR DESCRIPTION
From what I recall, `.gitattributes`, is checked recursively upwards until one is found and if none is found then it uses a default. Since there is a `.gitattributes` file here it's used, but it's missing the line ending setting so what file endings are used in the files stored in git can be whatever the author had it to (making it platform dependent).

When working on multiple platforms, you can get issues where your IDE doesn't understand the extra characters.

I've added the most common default. You can take it from there and maybe set up some specific things for images and fonts.

As an example, the React repo uses this same default:
https://github.com/facebook/react/blob/main/.gitattributes

> Note: Expect to see some extra file changes in the commits after this. It'll happen until all files has had their line endings normalized.
> You can also do a giant commit changing all of them, and then ignoring that commit when looking at the history with https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame