### PR TITLE
Allow null as return value of the mount components

### DIFF
--- a/packages/@react-facet/core/src/components/Map.tsx
+++ b/packages/@react-facet/core/src/components/Map.tsx
@@ -4,7 +4,7 @@ import { EqualityCheck, Facet, NO_VALUE } from '../types'
 
 export type MapProps<T> = {
   array: Facet<T[]>
-  children: (item: Facet<T>, index: number) => ReactElement
+  children: (item: Facet<T>, index: number) => ReactElement | null
   equalityCheck?: EqualityCheck<T>
 }
 
@@ -35,7 +35,7 @@ export const Map = <T,>({ array, children, equalityCheck }: MapProps<T>) => {
 type MapChildMemoProps<T> = {
   arrayFacet: Facet<T[]>
   index: number
-  children: (item: Facet<T>, index: number) => ReactElement
+  children: (item: Facet<T>, index: number) => ReactElement | null
   equalityCheck: EqualityCheck<T>
 }
 
@@ -55,7 +55,7 @@ const MapChildMemo = <T,>({ arrayFacet, index, children, equalityCheck }: MapChi
 type MapChildProps<T> = {
   arrayFacet: Facet<T[]>
   index: number
-  children: (item: Facet<T>, index: number) => ReactElement
+  children: (item: Facet<T>, index: number) => ReactElement | null
 }
 
 const MapChild = <T,>({ arrayFacet, index, children }: MapChildProps<T>) => {

--- a/packages/@react-facet/core/src/components/Mount.tsx
+++ b/packages/@react-facet/core/src/components/Mount.tsx
@@ -4,7 +4,7 @@ import { Facet } from '../types'
 
 type MountProps = {
   when: Facet<boolean | undefined>
-  children: ReactElement
+  children: ReactElement | null
   condition?: boolean
 }
 

--- a/packages/@react-facet/core/src/components/With.tsx
+++ b/packages/@react-facet/core/src/components/With.tsx
@@ -4,7 +4,7 @@ import { Facet, NoValue } from '../types'
 
 type WithProps<T> = {
   data: Facet<T | null | undefined>
-  children: (data: Facet<T>) => ReactElement
+  children: (data: Facet<T>) => ReactElement | null
 }
 
 const hasData = <T,>(_: Facet<T | null | undefined>, shouldRender: boolean | NoValue): _ is Facet<T> => {


### PR DESCRIPTION
Previously, only `ReactElement` was allowed as return value from the type, but there is not fundamental reason to forbid `null`, which can be useful.