### PR TITLE
Suppress twoslash implicit type error on hook examples

### DIFF
--- a/react-facet/docs/api/hooks.md
+++ b/react-facet/docs/api/hooks.md
@@ -24,7 +24,6 @@ This example illustrates how to use this hook in the common use case of having t
 
 ```tsx twoslash
 // @esModuleInterop
-// @errors: 7006
 import { useCallback } from 'react'
 import { render } from '@react-facet/dom-fiber'
 import { useFacetMap, useFacetState, useFacetCallback } from '@react-facet/core'
@@ -71,7 +70,6 @@ Say for example that you have a small form, and want to create a handler for the
 
 ```tsx twoslash
 // @esModuleInterop
-// @errors: 7006
 import { render } from '@react-facet/dom-fiber'
 interface Props {
   onSubmit: (value: string) => void


### PR DESCRIPTION
The error annotation for the twoslash code blocks on the `useFacetState` and `useFacetCallback` produce a visual error on the markdown in the documentation, warning of an implicit any type.

Whether this was intentional or not, I believe the TypeScript is correct enough to not warrant a drastic change of an example, since it doesn't cause a compiling error in React, but if such an annotation was intended, I do apologize for the misplacement.

The solution to fix this error without requiring the suppression of the error annotation would be to declare the type within the `useCallback` React function:

```diff
  const handleChange = useCallback(
-   (event) => {
+   (event: any) => {
      setValue((event.target as HTMLInputElement).value)
    },
    [setValue],
  )
  ```

This, of course, is a change to the documentation itself, and I felt was not necessary. Any changes and such are welcome of course, just figured I'd help!

Take care.