### PR TITLE
DOM Fiber: Fix memory leak caused by not removing child from parent

### DIFF
--- a/packages/@react-facet/dom-fiber/src/setupHostConfig.spec.tsx
+++ b/packages/@react-facet/dom-fiber/src/setupHostConfig.spec.tsx
@@ -1741,6 +1741,52 @@ describe('update', () => {
 })
 
 describe('umnount', () => {
+  it('hostConfig.removeChild should cleanup children instances', () => {
+    const hostConfig = setupHostConfig()
+    const child: ElementContainer = {
+      children: new Set(),
+      element: document.createElement('div'),
+      styleUnsubscribers: new Map(),
+    }
+
+    const parentInstance: ElementContainer = {
+      children: new Set(),
+      element: document.createElement('div'),
+      styleUnsubscribers: new Map(),
+    }
+
+    hostConfig.appendChild?.(parentInstance, child)
+
+    expect(parentInstance.children.size).toBe(1)
+
+    hostConfig.removeChild?.(parentInstance, child)
+
+    expect(parentInstance.children.size).toBe(0)
+  })
+
+  it('hostConfig.removeChildFromContainer should cleanup children instances', () => {
+    const hostConfig = setupHostConfig()
+    const child: ElementContainer = {
+      children: new Set(),
+      element: document.createElement('div'),
+      styleUnsubscribers: new Map(),
+    }
+
+    const parentInstance: ElementContainer = {
+      children: new Set(),
+      element: document.createElement('div'),
+      styleUnsubscribers: new Map(),
+    }
+
+    hostConfig.appendChild?.(parentInstance, child)
+
+    expect(parentInstance.children.size).toBe(1)
+
+    hostConfig.removeChildFromContainer?.(parentInstance, child)
+
+    expect(parentInstance.children.size).toBe(0)
+  })
+
   it('unsubscribes from all facets when a element component is unmounted', () => {
     const unsubscribe = jest.fn()
 

--- a/packages/@react-facet/dom-fiber/src/setupHostConfig.ts
+++ b/packages/@react-facet/dom-fiber/src/setupHostConfig.ts
@@ -928,7 +928,7 @@ export const setupHostConfig = (): HostConfig<
 
   removeChild: function (parentInstance, child) {
     if (isElementContainer(child)) {
-      cleanupElementContainer(child)
+      cleanupElementContainer(parentInstance, child)
     }
 
     parentInstance.element.removeChild(child.element)
@@ -940,7 +940,7 @@ export const setupHostConfig = (): HostConfig<
 
   removeChildFromContainer: function (container, child) {
     if (isElementContainer(child)) {
-      cleanupElementContainer(child)
+      cleanupElementContainer(container, child)
     }
 
     container.element.removeChild(child.element)
@@ -959,7 +959,9 @@ export const setupHostConfig = (): HostConfig<
   },
 })
 
-const cleanupElementContainer = (instance: ElementContainer) => {
+const cleanupElementContainer = (parent: ElementContainer, instance: ElementContainer) => {
+  parent.children.delete(instance)
+
   instance.styleUnsubscribers?.forEach((unsubscribe) => unsubscribe())
   instance.styleUnsubscribers?.clear()
 


### PR DESCRIPTION
Internally we need to keep track of parent-children relationships of Host Components to properly call unsubscribe of any used Facets.

Previously we properly cleaned up any children as all of its descendants, but we never removed the child from its original parent.

This fixes the leak with an accompanying unit test.