### PR TITLE
Fix createFacet equalityCheck to not fire for undefined or null

### DIFF
--- a/packages/@react-facet/core/src/facet/createFacet.spec.ts
+++ b/packages/@react-facet/core/src/facet/createFacet.spec.ts
@@ -72,6 +72,32 @@ describe('equalityChecks', () => {
       expect(update).toHaveBeenCalledTimes(0)
     })
 
+    it('does not fire for null', () => {
+      const update = jest.fn()
+      const initialValue = null
+      const mock = createFacet({ initialValue, equalityCheck: defaultEqualityCheck })
+      mock.observe(update)
+      expect(update).toHaveBeenCalledTimes(1)
+      expect(update).toHaveBeenCalledWith(initialValue)
+
+      update.mockClear()
+      mock.set(initialValue)
+      expect(update).toHaveBeenCalledTimes(0)
+    })
+
+    it('does not fire for undefined', () => {
+      const update = jest.fn()
+      const initialValue = undefined
+      const mock = createFacet({ initialValue, equalityCheck: defaultEqualityCheck })
+      mock.observe(update)
+      expect(update).toHaveBeenCalledTimes(1)
+      expect(update).toHaveBeenCalledWith(initialValue)
+
+      update.mockClear()
+      mock.set(initialValue)
+      expect(update).toHaveBeenCalledTimes(0)
+    })
+
     it('fires if the primitive value changed', () => {
       const update = jest.fn()
       const initialValue = 'initial'

--- a/packages/@react-facet/core/src/facet/createFacet.ts
+++ b/packages/@react-facet/core/src/facet/createFacet.ts
@@ -27,7 +27,11 @@ export function createFacet<V>({ initialValue, startSubscription, equalityCheck 
       if (equalityCheck === defaultEqualityCheck) {
         const typeofValue = typeof newValue
         if (
-          (typeofValue === 'number' || typeofValue === 'string' || typeofValue === 'boolean') &&
+          (typeofValue === 'number' ||
+            typeofValue === 'string' ||
+            typeofValue === 'boolean' ||
+            newValue === null ||
+            newValue === undefined) &&
           currentValue === newValue
         ) {
           return

--- a/packages/@react-facet/core/src/hooks/useFacetWrap.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetWrap.spec.tsx
@@ -152,7 +152,7 @@ describe('does not trigger effect updates on re-renders when the unchanged wrapp
   })
   it('boolean', () => {
     testEffectUpdatesOnStaticValue(false, false)
-    testEffectUpdatesOnStaticValue(false, false)
+    testEffectUpdatesOnStaticValue(true, false)
   })
   it('number', () => {
     testEffectUpdatesOnStaticValue(0, false)


### PR DESCRIPTION
While debugging I noticed that undefined/null when wrapped with `useFacetWrap()` and used as a facet dependency in a `useFacetEffect()` tends to trigger the effect on every re-render. despite the value not ever changing.

After a bit of digging I believe I found a bug in the optimisation logic for defaultEqualityCheck inside the update function for `createFacet` method, This PR fixes that discrepancy in the logic that caused this behaviour

I've also added tests for both useFacetWrap and createFacet to make sure it doesn't break in the future