### PR TITLE
Added createFacetContext

### DIFF
--- a/packages/@react-facet/core/src/createFacetContext.spec.tsx
+++ b/packages/@react-facet/core/src/createFacetContext.spec.tsx
@@ -1,0 +1,73 @@
+import React, { useContext } from 'react'
+import { act, render } from '@react-facet/dom-fiber-testing-library'
+import { createFacetContext } from './createFacetContext'
+import { useFacetState } from './hooks'
+import { Setter } from './types'
+
+it(`has default value`, () => {
+  const defaultValue = 'defaultValue'
+  const context = createFacetContext(defaultValue)
+  const Component = () => {
+    const stringFacet = useContext(context)
+    return <fast-text text={stringFacet}></fast-text>
+  }
+
+  const result = render(<Component />)
+
+  expect(result.baseElement).toContainHTML(defaultValue)
+})
+
+it(`allows provider to set new value`, () => {
+  const defaultValue = 'defaultValue'
+  const context = createFacetContext(defaultValue)
+  const Component = () => {
+    const stringFacet = useContext(context)
+    return <fast-text text={stringFacet}></fast-text>
+  }
+  const newValue = 'newValue'
+  const App = () => {
+    const [facet] = useFacetState(newValue)
+
+    return (
+      <context.Provider value={facet}>
+        <Component />
+      </context.Provider>
+    )
+  }
+  const result = render(<App />)
+
+  expect(result.baseElement).toContainHTML(newValue)
+})
+
+it(`it updates the context value without re-conciliation`, () => {
+  const defaultValue = 'defaultValue'
+  const context = createFacetContext(defaultValue)
+  const Component = () => {
+    const stringFacet = useContext(context)
+    return <fast-text text={stringFacet}></fast-text>
+  }
+  const newValue = 'newValue'
+  let setFacet: Setter<string>
+  const hasRenderedMock = jest.fn()
+  const App = () => {
+    const [stringFacet, setStringFacet] = useFacetState(newValue)
+    setFacet = setStringFacet
+    hasRenderedMock()
+    return (
+      <context.Provider value={stringFacet}>
+        <Component />
+      </context.Provider>
+    )
+  }
+  const result = render(<App />)
+
+  expect(hasRenderedMock).toBeCalledTimes(1)
+  expect(result.baseElement).toContainHTML(newValue)
+  const evenNewerValue = 'newNewValue'
+  act(() => {
+    setFacet(evenNewerValue)
+  })
+
+  expect(result.baseElement).toContainHTML(evenNewerValue)
+  expect(hasRenderedMock).toBeCalledTimes(1)
+})

--- a/packages/@react-facet/core/src/createFacetContext.tsx
+++ b/packages/@react-facet/core/src/createFacetContext.tsx
@@ -1,0 +1,17 @@
+import { createContext } from 'react'
+import { Facet } from './types'
+
+export function createFacetContext<T>(initialValue: T) {
+  const facet: Facet<T> = {
+    get: () => initialValue,
+    observe: (listener) => {
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('Missing Provider')
+      }
+      listener(initialValue)
+      return () => {}
+    },
+  }
+  const context = createContext(facet)
+  return context
+}

--- a/packages/@react-facet/core/src/index.ts
+++ b/packages/@react-facet/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './components'
 export * from './createEqualityChecks'
+export * from './createFacetContext'
 export * from './equalityChecks'
 export * from './facet'
 export * from './helpers'


### PR DESCRIPTION
This PR adds a new facet function `createFacetContext`

Which can be used to create a context that holds a facet with the type `Facet` instead of `WritableFacet`.

**NOTE:** Writable facets you provide into the context provider are still technically writable as you can call them with `.set()` however the function will change the type to show that the facet doesn't have a setter internally (in reality it does).

This hopefully will help steer consumers away from setting facets arbitrarily using `createFacet` and `facet.set()` instead of sticking to more conventional react methods and or `useFacetX` hooks

this turns code like this

```tsx
const myFancyContext = createContext<Facet<number | undefined>>(createFacet({ initialValue: undefined }))
export const useMyFancyContext = () => useContext(myFancyContext)
```

into 

```tsx
const myFancyContext = createFacetContext<number | undefined>(undefined)
export const useMyFancyContext = () => useContext(myFancyContext)
```

In the first instance the Facet was a WritableFacet and was gonna stay that way no matter what, in the 2nd instance it is no longer a WritableFacet, which hopefully should offer a cleaner method of writing a context holding a facet for it's property of not triggering reconciliation and not for it's property of being a writable store of value.