### PR TITLE
Added defaultEqualityCheck to createFacet, and introduced createStaticFacet

### DIFF
--- a/packages/@react-facet/core/src/createFacetContext.tsx
+++ b/packages/@react-facet/core/src/createFacetContext.tsx
@@ -1,8 +1,8 @@
-import { createFakeFacet } from './facet/createFakeFacet'
+import { createStaticFacet } from './facet/createStaticFacet'
 import { createContext } from 'react'
 
 export function createFacetContext<T>(initialValue: T) {
-  const facet = createFakeFacet(initialValue)
+  const facet = createStaticFacet(initialValue)
   const context = createContext(facet)
   return context
 }

--- a/packages/@react-facet/core/src/createFacetContext.tsx
+++ b/packages/@react-facet/core/src/createFacetContext.tsx
@@ -1,8 +1,19 @@
-import { createStaticFacet } from './facet/createStaticFacet'
 import { createContext } from 'react'
+import { Facet } from './types'
 
 export function createFacetContext<T>(initialValue: T) {
-  const facet = createStaticFacet(initialValue)
+  const facet: Facet<T> = {
+    get: () => initialValue,
+    observe: (listener) => {
+      if (process.env.NODE_ENV !== 'production') {
+        console.log(
+          `Accessing a static facet created through createFacetContext, perhaps you're missing a Context Provider?`,
+        )
+      }
+      listener(initialValue)
+      return () => {}
+    },
+  }
   const context = createContext(facet)
   return context
 }

--- a/packages/@react-facet/core/src/createFacetContext.tsx
+++ b/packages/@react-facet/core/src/createFacetContext.tsx
@@ -1,17 +1,8 @@
+import { createFakeFacet } from './facet/createFakeFacet'
 import { createContext } from 'react'
-import { Facet } from './types'
 
 export function createFacetContext<T>(initialValue: T) {
-  const facet: Facet<T> = {
-    get: () => initialValue,
-    observe: (listener) => {
-      if (process.env.NODE_ENV !== 'production') {
-        console.log('Missing Provider')
-      }
-      listener(initialValue)
-      return () => {}
-    },
-  }
+  const facet = createFakeFacet(initialValue)
   const context = createContext(facet)
   return context
 }

--- a/packages/@react-facet/core/src/facet/createFacet.spec.ts
+++ b/packages/@react-facet/core/src/facet/createFacet.spec.ts
@@ -1,5 +1,4 @@
 import 'react'
-import { defaultEqualityCheck } from '../equalityChecks'
 import { NO_VALUE } from '../types'
 import { createFacet } from './createFacet'
 
@@ -8,7 +7,7 @@ describe('equalityChecks', () => {
     it('fires for object values, since it can be mutated', () => {
       const update = jest.fn()
       const initialValue = {}
-      const mock = createFacet({ initialValue, equalityCheck: defaultEqualityCheck })
+      const mock = createFacet({ initialValue })
       mock.observe(update)
       expect(update).toHaveBeenCalledTimes(1)
       expect(update).toHaveBeenCalledWith(initialValue)
@@ -22,7 +21,7 @@ describe('equalityChecks', () => {
     it('fires for array values, since it can be mutated', () => {
       const update = jest.fn()
       const initialValue: string[] = []
-      const mock = createFacet({ initialValue, equalityCheck: defaultEqualityCheck })
+      const mock = createFacet({ initialValue })
       mock.observe(update)
       expect(update).toHaveBeenCalledTimes(1)
       expect(update).toHaveBeenCalledWith(initialValue)
@@ -36,7 +35,7 @@ describe('equalityChecks', () => {
     it('does not fire for string', () => {
       const update = jest.fn()
       const initialValue = 'string'
-      const mock = createFacet({ initialValue, equalityCheck: defaultEqualityCheck })
+      const mock = createFacet({ initialValue })
       mock.observe(update)
       expect(update).toHaveBeenCalledTimes(1)
       expect(update).toHaveBeenCalledWith(initialValue)
@@ -49,7 +48,7 @@ describe('equalityChecks', () => {
     it('does not fire for boolean', () => {
       const update = jest.fn()
       const initialValue = true
-      const mock = createFacet({ initialValue, equalityCheck: defaultEqualityCheck })
+      const mock = createFacet({ initialValue })
       mock.observe(update)
       expect(update).toHaveBeenCalledTimes(1)
       expect(update).toHaveBeenCalledWith(initialValue)
@@ -62,7 +61,7 @@ describe('equalityChecks', () => {
     it('does not fire for number', () => {
       const update = jest.fn()
       const initialValue = 1
-      const mock = createFacet({ initialValue, equalityCheck: defaultEqualityCheck })
+      const mock = createFacet({ initialValue })
       mock.observe(update)
       expect(update).toHaveBeenCalledTimes(1)
       expect(update).toHaveBeenCalledWith(initialValue)
@@ -75,7 +74,7 @@ describe('equalityChecks', () => {
     it('does not fire for null', () => {
       const update = jest.fn()
       const initialValue = null
-      const mock = createFacet({ initialValue, equalityCheck: defaultEqualityCheck })
+      const mock = createFacet({ initialValue })
       mock.observe(update)
       expect(update).toHaveBeenCalledTimes(1)
       expect(update).toHaveBeenCalledWith(initialValue)
@@ -88,7 +87,7 @@ describe('equalityChecks', () => {
     it('does not fire for undefined', () => {
       const update = jest.fn()
       const initialValue = undefined
-      const mock = createFacet({ initialValue, equalityCheck: defaultEqualityCheck })
+      const mock = createFacet({ initialValue })
       mock.observe(update)
       expect(update).toHaveBeenCalledTimes(1)
       expect(update).toHaveBeenCalledWith(initialValue)
@@ -101,7 +100,7 @@ describe('equalityChecks', () => {
     it('fires if the primitive value changed', () => {
       const update = jest.fn()
       const initialValue = 'initial'
-      const mock = createFacet({ initialValue, equalityCheck: defaultEqualityCheck })
+      const mock = createFacet({ initialValue })
       mock.observe(update)
       expect(update).toHaveBeenCalledTimes(1)
       expect(update).toHaveBeenCalledWith(initialValue)

--- a/packages/@react-facet/core/src/facet/createFacet.ts
+++ b/packages/@react-facet/core/src/facet/createFacet.ts
@@ -12,7 +12,9 @@ export interface FacetOptions<V> {
   startSubscription?: StartSubscription<V>
   equalityCheck?: EqualityCheck<V>
 }
-
+/**
+ * The low level function to create a Facet, not recommended to be used if you can use any of the react facet hooks to create facets instead (Ex: useFacetState, useFacetWrap)
+ */
 export function createFacet<V>({
   initialValue,
   startSubscription,

--- a/packages/@react-facet/core/src/facet/createFacet.ts
+++ b/packages/@react-facet/core/src/facet/createFacet.ts
@@ -13,7 +13,11 @@ export interface FacetOptions<V> {
   equalityCheck?: EqualityCheck<V>
 }
 
-export function createFacet<V>({ initialValue, startSubscription, equalityCheck }: FacetOptions<V>): WritableFacet<V> {
+export function createFacet<V>({
+  initialValue,
+  startSubscription,
+  equalityCheck = defaultEqualityCheck,
+}: FacetOptions<V>): WritableFacet<V> {
   const listeners: Set<Listener<V>> = new Set()
   let currentValue = initialValue
   let cleanupSubscription: Cleanup | undefined

--- a/packages/@react-facet/core/src/facet/createFakeFacet.ts
+++ b/packages/@react-facet/core/src/facet/createFakeFacet.ts
@@ -1,0 +1,17 @@
+import { Facet } from '..'
+/**
+ * Creates a nonwritable barebones facet to be used when you need an initial facet value that's meant to be replaced later by a real facet. Ex: with `useContext()`
+ */
+export function createFakeFacet<T>(value: T): Facet<T> {
+  const facet: Facet<T> = {
+    get: () => value,
+    observe: (listener) => {
+      if (process.env.NODE_ENV !== 'production') {
+        console.log(`Accessing a fake facet, perhaps you're missing a Context Provider?`)
+      }
+      listener(value)
+      return () => {}
+    },
+  }
+  return facet
+}

--- a/packages/@react-facet/core/src/facet/createStaticFacet.spec.ts
+++ b/packages/@react-facet/core/src/facet/createStaticFacet.spec.ts
@@ -1,0 +1,46 @@
+import { createStaticFacet } from './createStaticFacet'
+
+describe('createStaticFacet', () => {
+  const env = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...env }
+  })
+
+  afterEach(() => {
+    process.env = env
+  })
+
+  it(`it can be read but not mutated`, () => {
+    const initialValue = {}
+    const mock = createStaticFacet(initialValue)
+
+    expect(mock.get()).toBe(initialValue)
+    expect('set' in mock).toBe(false)
+  })
+
+  it(`it responds with the same value if you observe it and warns you in a non-production environment`, () => {
+    const consoleLogMock = jest.spyOn(console, 'log').mockImplementation()
+
+    const update = jest.fn()
+    const initialValue = {}
+    const mock = createStaticFacet(initialValue)
+
+    mock.observe(update)
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update).toHaveBeenCalledWith(initialValue)
+    expect(consoleLogMock).toHaveBeenCalledTimes(1)
+    expect(consoleLogMock).toHaveBeenCalledWith(`Accessing a static facet, perhaps you're missing a Context Provider?`)
+
+    update.mockClear()
+    consoleLogMock.mockClear()
+
+    process.env.NODE_ENV = 'production'
+
+    mock.observe(update)
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update).toHaveBeenCalledWith(initialValue)
+    expect(consoleLogMock).toHaveBeenCalledTimes(0)
+  })
+})

--- a/packages/@react-facet/core/src/facet/createStaticFacet.spec.ts
+++ b/packages/@react-facet/core/src/facet/createStaticFacet.spec.ts
@@ -1,17 +1,6 @@
 import { createStaticFacet } from './createStaticFacet'
 
 describe('createStaticFacet', () => {
-  const env = process.env
-
-  beforeEach(() => {
-    jest.resetModules()
-    process.env = { ...env }
-  })
-
-  afterEach(() => {
-    process.env = env
-  })
-
   it(`it can be read but not mutated`, () => {
     const initialValue = {}
     const mock = createStaticFacet(initialValue)
@@ -21,8 +10,6 @@ describe('createStaticFacet', () => {
   })
 
   it(`it responds with the same value if you observe it and warns you in a non-production environment`, () => {
-    const consoleLogMock = jest.spyOn(console, 'log').mockImplementation()
-
     const update = jest.fn()
     const initialValue = {}
     const mock = createStaticFacet(initialValue)
@@ -30,17 +17,11 @@ describe('createStaticFacet', () => {
     mock.observe(update)
     expect(update).toHaveBeenCalledTimes(1)
     expect(update).toHaveBeenCalledWith(initialValue)
-    expect(consoleLogMock).toHaveBeenCalledTimes(1)
-    expect(consoleLogMock).toHaveBeenCalledWith(`Accessing a static facet, perhaps you're missing a Context Provider?`)
 
     update.mockClear()
-    consoleLogMock.mockClear()
-
-    process.env.NODE_ENV = 'production'
 
     mock.observe(update)
     expect(update).toHaveBeenCalledTimes(1)
     expect(update).toHaveBeenCalledWith(initialValue)
-    expect(consoleLogMock).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/@react-facet/core/src/facet/createStaticFacet.ts
+++ b/packages/@react-facet/core/src/facet/createStaticFacet.ts
@@ -2,7 +2,7 @@ import { Facet } from '..'
 /**
  * Creates a nonwritable barebones facet to be used when you need an initial facet value that's meant to be replaced later by a real facet. Ex: with `useContext()`
  */
-export function createFakeFacet<T>(value: T): Facet<T> {
+export function createStaticFacet<T>(value: T): Facet<T> {
   const facet: Facet<T> = {
     get: () => value,
     observe: (listener) => {

--- a/packages/@react-facet/core/src/facet/createStaticFacet.ts
+++ b/packages/@react-facet/core/src/facet/createStaticFacet.ts
@@ -7,9 +7,6 @@ export function createStaticFacet<T>(value: T): Facet<T> {
   const facet: Facet<T> = {
     get: () => value,
     observe: (listener) => {
-      if (process.env.NODE_ENV !== 'production') {
-        console.log(`Accessing a static facet, perhaps you're missing a Context Provider?`)
-      }
       listener(value)
       return () => {}
     },

--- a/packages/@react-facet/core/src/facet/createStaticFacet.ts
+++ b/packages/@react-facet/core/src/facet/createStaticFacet.ts
@@ -1,6 +1,7 @@
 import { Facet } from '..'
 /**
- * Creates a nonwritable barebones facet to be used when you need an initial facet value that's meant to be replaced later by a real facet. Ex: with `useContext()`
+ * Creates a nonwritable barebones static facet to be used when you need an initial facet value outside the react context
+ * that's meant to be replaced later by a real facet. Ex: with `createContext()`
  */
 export function createStaticFacet<T>(value: T): Facet<T> {
   const facet: Facet<T> = {

--- a/packages/@react-facet/core/src/facet/createStaticFacet.ts
+++ b/packages/@react-facet/core/src/facet/createStaticFacet.ts
@@ -8,7 +8,7 @@ export function createStaticFacet<T>(value: T): Facet<T> {
     get: () => value,
     observe: (listener) => {
       if (process.env.NODE_ENV !== 'production') {
-        console.log(`Accessing a fake facet, perhaps you're missing a Context Provider?`)
+        console.log(`Accessing a static facet, perhaps you're missing a Context Provider?`)
       }
       listener(value)
       return () => {}

--- a/packages/@react-facet/core/src/facet/index.ts
+++ b/packages/@react-facet/core/src/facet/index.ts
@@ -1,2 +1,3 @@
 export * from './createFacet'
 export * from './createReadOnlyFacet'
+export * from './createStaticFacet'

--- a/packages/@react-facet/core/src/index.spec.ts
+++ b/packages/@react-facet/core/src/index.spec.ts
@@ -10,7 +10,12 @@ describe('regression testing preventing accidental removal of APIs', () => {
 
   it('exposes the core facets', () => {
     expect(facet.createFacet).toBeDefined()
+    expect(facet.createStaticFacet).toBeDefined()
     expect(facet.createReadOnlyFacet).toBeDefined()
+  })
+
+  it('exposes the react facet methods', () => {
+    expect(facet.createFacetContext).toBeDefined()
   })
 
   it('exposes the hooks', () => {


### PR DESCRIPTION
This PR does two things
- Changes the default behaviour for createFacet to not update without doing a defaultEqualityCheck
- Introduces `createStaticFacet` function to create initial facets outside the react context that are meant to be replaced later by real facet in the react context. Such valid use-case is for example with `createContext` like so
```tsx
const myFancyContext = createContext<Facet<number | undefined>>(createStaticFacet(undefined))
export const useMyFancyContext = () => useContext(myFancyContext)
```
Now your context facet is completely static, not writable and if by accident you manage to observe it won't register any listeners and will give you a warning in production.
