### PR TITLE
Optimizes looping Facet listeners

### DIFF
--- a/examples/benchmarking/README.md
+++ b/examples/benchmarking/README.md
@@ -24,7 +24,7 @@ And open the examples in the target platform. Ex: http://localhost:8080/listMemo
 
 ## Comparing
 
-There is a compare script that runs the comparison automatically using Chrome. Simply pass the two examples to compare and a target relative performance:
+There is a compare script that runs the comparison automatically using Chrome in JIT-less mode. Simply pass the two examples to compare and a target relative performance:
 
 ```
 yarn compare progressBarFacet progressBarState 74

--- a/examples/benchmarking/compare.ts
+++ b/examples/benchmarking/compare.ts
@@ -21,7 +21,9 @@ const compare = async (optionA: string, optionB: string, targetRelativePerforman
     process.exit(1)
   }
 
-  const browser = await puppeteer.launch()
+  // Runs the browser with JIT disabled, given the main target platform for Facet are game consoles
+  // and they don't have JIT available.
+  const browser = await puppeteer.launch({ args: ['--js-flags="--jitless"'] })
 
   interface TraceEvent {
     name: string

--- a/packages/@react-facet/core/src/facet/createFacet.ts
+++ b/packages/@react-facet/core/src/facet/createFacet.ts
@@ -60,14 +60,15 @@ export function createFacet<V>({
       listenerCleanups = []
     }
 
-    for (const listener of listeners) {
-      const cleanup = listener(currentValue)
+    // forEach has proven to be faster than "for...of" for JIT less environments
+    listeners.forEach((listener) => {
+      const cleanup = listener(currentValue as V)
 
       // if the listener returns a cleanup function, we store it to call latter
       if (cleanup != null) {
         listenerCleanups.push({ cleanup, listener })
       }
-    }
+    })
   }
 
   /**


### PR DESCRIPTION
Using the https://esbench.com/bench/6317fc2a6c89f600a5701bc9 in a JIT less environment, we confirmed this method to be the fastest to loop the listeners:

![image](https://user-images.githubusercontent.com/6001/192710505-6c5ec015-dcee-4110-a425-9786a0896a8a.png)

Although the difference is too small to be caught by our current automated benchmark tests.

When JIT is available, using an `Array` would be more performant, but given we are targeting game consoles as our main platform and they don't have JIT available, a `Set` with a `forEach` is the better option.

To test without JIT, I have used Chrome with the flag `--js-flags="--jitless"`.