### PR TITLE
Make the createFacetContext only log when node env is development

### DIFF
--- a/packages/@react-facet/core/src/createFacetContext.spec.tsx
+++ b/packages/@react-facet/core/src/createFacetContext.spec.tsx
@@ -108,6 +108,8 @@ describe('createFacetContext initial facet', () => {
 
     const update = jest.fn()
 
+    process.env.NODE_ENV = 'development'
+
     staticFacet.observe(update)
     expect(update).toHaveBeenCalledTimes(1)
     expect(update).toHaveBeenCalledWith(defaultValue)
@@ -120,10 +122,10 @@ describe('createFacetContext initial facet', () => {
     consoleLogMock.mockClear()
 
     process.env.NODE_ENV = 'production'
-
     staticFacet.observe(update)
     expect(update).toHaveBeenCalledTimes(1)
     expect(update).toHaveBeenCalledWith(defaultValue)
     expect(consoleLogMock).toHaveBeenCalledTimes(0)
+    process.env.NODE_ENV = 'test'
   })
 })

--- a/packages/@react-facet/core/src/createFacetContext.tsx
+++ b/packages/@react-facet/core/src/createFacetContext.tsx
@@ -5,7 +5,7 @@ export function createFacetContext<T>(initialValue: T) {
   const facet: Facet<T> = {
     get: () => initialValue,
     observe: (listener) => {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV === 'development') {
         console.log(
           `Accessing a static facet created through createFacetContext, perhaps you're missing a Context Provider?`,
         )


### PR DESCRIPTION
## Overview
It becomes difficult to read any test output because of this `console.log` statement. If we really want it to log during tests I think we should add a ceiling to how many times it can do so.