### PR TITLE
Added improved logging to static facet context

### DIFF
--- a/packages/@react-facet/core/src/createFacetContext.spec.tsx
+++ b/packages/@react-facet/core/src/createFacetContext.spec.tsx
@@ -114,7 +114,8 @@ describe('createFacetContext initial facet', () => {
     expect(update).toHaveBeenCalledWith(defaultValue)
     expect(consoleLogMock).toHaveBeenCalledTimes(1)
     expect(consoleLogMock).toHaveBeenCalledWith(
-      `Accessing a static facet created through createFacetContext, perhaps you're missing a Context Provider?`,
+      `Accessing a static facet created through createFacetContext, perhaps you're missing a Context Provider? initialValue: `,
+      JSON.stringify(defaultValue),
     )
 
     update.mockClear()
@@ -126,6 +127,7 @@ describe('createFacetContext initial facet', () => {
     expect(update).toHaveBeenCalledTimes(1)
     expect(update).toHaveBeenCalledWith(defaultValue)
     expect(consoleLogMock).toHaveBeenCalledTimes(0)
+    process.env.NODE_ENV = 'test' // Restore NODE_ENV back to test to not mess with subsequent tests
   })
 
   it(`it responds with the same value if you observe it and warns you in a non-production environment`, () => {
@@ -139,7 +141,8 @@ describe('createFacetContext initial facet', () => {
     expect(update).toHaveBeenCalledWith(defaultValue)
     expect(consoleLogMock).toHaveBeenCalledTimes(1)
     expect(consoleLogMock).toHaveBeenCalledWith(
-      `Accessing a static facet created through createFacetContext, perhaps you're missing a Context Provider?`,
+      `Accessing a static facet created through createFacetContext, perhaps you're missing a Context Provider? initialValue: `,
+      JSON.stringify(defaultValue),
     )
 
     update.mockClear()

--- a/packages/@react-facet/core/src/createFacetContext.tsx
+++ b/packages/@react-facet/core/src/createFacetContext.tsx
@@ -23,7 +23,7 @@ export function createFacetContext<T>(initialValue: T) {
 
 function parseInitialValue<T>(initialValue: T) {
   try {
-    return JSON.stringify(initialValue)
+    return JSON.stringify(initialValue, null, 2)
   } catch (e) {
     return initialValue
   }

--- a/packages/@react-facet/core/src/createFacetContext.tsx
+++ b/packages/@react-facet/core/src/createFacetContext.tsx
@@ -2,13 +2,16 @@ import { createContext } from 'react'
 import { Facet } from './types'
 
 export function createFacetContext<T>(initialValue: T) {
+  let warnedAboutInvalidAccess = false
   const facet: Facet<T> = {
     get: () => initialValue,
     observe: (listener) => {
-      if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
+      if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test' && !warnedAboutInvalidAccess) {
         console.log(
-          `Accessing a static facet created through createFacetContext, perhaps you're missing a Context Provider?`,
+          `Accessing a static facet created through createFacetContext, perhaps you're missing a Context Provider? initialValue: `,
+          parseInitialValue(initialValue),
         )
+        warnedAboutInvalidAccess = true
       }
       listener(initialValue)
       return () => {}
@@ -16,4 +19,12 @@ export function createFacetContext<T>(initialValue: T) {
   }
   const context = createContext(facet)
   return context
+}
+
+function parseInitialValue<T>(initialValue: T) {
+  try {
+    return JSON.stringify(initialValue)
+  } catch (e) {
+    return initialValue
+  }
 }


### PR DESCRIPTION
Now the access static facet without overriding initialValue log should not show more than once per instance and when it shows it should log the initialValue

Also cherrypicked fix for env during jest test run from @creativecreature's PR #100 