### PR TITLE
Make it possible to supply an initial value for useFacetRef

### DIFF
--- a/packages/@react-facet/core/src/hooks/useFacetRef.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetRef.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render } from '@react-facet/dom-fiber-testing-library'
 import { useFacetRef } from './useFacetRef'
 import { createFacet } from '../facet'
-import { NoValue } from '..'
+import { NoValue, NO_VALUE } from '..'
 
 it('passes a value into the ref', () => {
   const mockFacet = createFacet({ initialValue: 'value' })
@@ -18,4 +18,52 @@ it('passes a value into the ref', () => {
   expect(ref.current).toBe('value')
   mockFacet.set('changed')
   expect(ref.current).toBe('changed')
+})
+
+it('should default to no NO_VALUE', () => {
+  const mockFacet = createFacet<string>({ initialValue: NO_VALUE })
+  let ref: React.RefObject<string | NoValue> = React.createRef()
+
+  const ComponentWithFacetEffect: React.FC = () => {
+    ref = useFacetRef(mockFacet)
+    expect(ref.current).toBe(NO_VALUE)
+    return <span />
+  }
+
+  render(<ComponentWithFacetEffect />)
+  expect(ref.current).toBe(NO_VALUE)
+  mockFacet.set('value')
+  expect(ref.current).toBe('value')
+})
+
+it('should be able to set a default value', () => {
+  const mockFacet = createFacet<string>({ initialValue: NO_VALUE })
+  let ref: React.RefObject<string | NoValue> = React.createRef()
+
+  const ComponentWithFacetEffect: React.FC = () => {
+    ref = useFacetRef(mockFacet, 'fallback')
+    expect(ref.current).toBe('fallback')
+    return <span />
+  }
+
+  render(<ComponentWithFacetEffect />)
+  expect(ref.current).toBe('fallback')
+  mockFacet.set('value')
+  expect(ref.current).toBe('value')
+})
+
+it('should ignore the default state if the facet has a value', () => {
+  const mockFacet = createFacet<string>({ initialValue: 'initialValue' })
+  let ref: React.RefObject<string | NoValue> = React.createRef()
+
+  const ComponentWithFacetEffect: React.FC = () => {
+    ref = useFacetRef(mockFacet, 'fallback')
+    expect(ref.current).toBe('initialValue')
+    return <span />
+  }
+
+  render(<ComponentWithFacetEffect />)
+  expect(ref.current).toBe('initialValue')
+  mockFacet.set('value')
+  expect(ref.current).toBe('value')
 })

--- a/packages/@react-facet/core/src/hooks/useFacetRef.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetRef.ts
@@ -1,12 +1,17 @@
+import { useRef, MutableRefObject } from 'react'
 import { Facet } from '../types'
-import { useRef } from 'react'
 import { useFacetEffect } from './useFacetEffect'
-import { NoValue } from '..'
+import { NO_VALUE, Option } from '..'
 
-export const useFacetRef = <T>(facet: Facet<T>) => {
-  const value = facet.get()
-  const ref = useRef<T | NoValue>(value)
+export function useFacetRef<T>(facet: Facet<T>): MutableRefObject<Option<T>>
+export function useFacetRef<T>(facet: Facet<T>, defaultValue: T): MutableRefObject<T>
+export function useFacetRef<T>(facet: Facet<T>, defaultValue?: T): MutableRefObject<T> {
+  let value = facet.get()
+  if (value === NO_VALUE && defaultValue != undefined) {
+    value = defaultValue
+  }
 
+  const ref = useRef<Option<T>>(value)
   useFacetEffect(
     (value) => {
       ref.current = value
@@ -15,5 +20,5 @@ export const useFacetRef = <T>(facet: Facet<T>) => {
     [facet],
   )
 
-  return ref
+  return ref as MutableRefObject<T>
 }


### PR DESCRIPTION
## Overview
Reacts `useRef` allows you to supply a default value. When using `useFacetRef` it can get a little verbose to have to check it against `NO_VALUE`. 

```typescript
const mockFacet: Facet<string> ....
const ref = useFacetRef(mockFacet) // MutableRefObject<Option<string>>
```

```typescript
const mockFacet: Facet<string> ....
const ref = useFacetRef(mockFacet, 'fallback') // MutableRefObject<string>
```