### PR TITLE
Support defaultReturnValue in useFacetCallback

### DIFF
--- a/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
@@ -198,3 +198,34 @@ it('has proper return type with NO_VALUE in it', () => {
 
   render(<TestComponent />)
 })
+
+it('returns the defaultValue, when provided, if any facet has NO_VALUE and skip calling the callback', () => {
+  const facetA = createFacet({ initialValue: 'a' })
+  const facetB = createFacet<number>({ initialValue: NO_VALUE })
+
+  const callback = jest.fn()
+  let handler: (event: string) => string
+
+  const TestComponent = ({ dependency }: { dependency: string }) => {
+    handler = useFacetCallback(
+      (valueA, valueB) => (event: string) => {
+        callback(valueA, valueB, dependency, event)
+        return `${valueA} ${valueB}`
+      },
+      [dependency],
+      [facetA, facetB],
+      'default value',
+    )
+
+    return null
+  }
+
+  render(<TestComponent dependency="dependency" />)
+
+  act(() => {
+    const result = handler('event')
+    expect(result).toBe('default value')
+  })
+
+  expect(callback).not.toHaveBeenCalledWith()
+})

--- a/packages/@react-facet/core/src/hooks/useFacetCallback.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.ts
@@ -9,6 +9,7 @@ import { Facet, NO_VALUE, Option, ExtractFacetValues } from '../types'
  * @param callback function callback that receives the current facet values and the arguments passed to the callback
  * @param dependencies variable used by the callback that are available in scope (similar as dependencies of useCallback)
  * @param facets facets that the callback listens to
+ * @param defaultReturnValue a default value to be returned by the callback, if the facets don't have any value yet
  *
  * We pass the dependencies of the callback as the second argument so we can leverage the eslint-plugin-react-hooks option for additionalHooks.
  * Having this as the second argument allows the linter to work.
@@ -17,6 +18,31 @@ export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y]
   callback: (...args: ExtractFacetValues<T>) => (...args: K) => M,
   dependencies: unknown[],
   facets: T,
+  defaultReturnValue: M,
+): (...args: K) => M
+
+/**
+ * Creates a callback that depends on the value of a facet.
+ * Very similar to `useCallback` from `React`
+ *
+ * @param callback function callback that receives the current facet values and the arguments passed to the callback
+ * @param dependencies variable used by the callback that are available in scope (similar as dependencies of useCallback)
+ * @param facets facets that the callback listens to
+ *
+ * We pass the dependencies of the callback as the second argument so we can leverage the eslint-plugin-react-hooks option for additionalHooks.
+ * Having this as the second argument allows the linter to work.
+ */
+export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y], K extends [...unknown[]]>(
+  callback: (...args: ExtractFacetValues<T>) => (...args: K) => M,
+  dependencies: unknown[],
+  facets: T,
+): (...args: K) => M | NoValue
+
+export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y], K extends [...unknown[]]>(
+  callback: (...args: ExtractFacetValues<T>) => (...args: K) => M,
+  dependencies: unknown[],
+  facets: T,
+  defaultReturnValue?: M,
 ): (...args: K) => M | NoValue {
   const facetsRef = useRef<Option<unknown>[]>(facets.map(() => NO_VALUE))
 
@@ -44,11 +70,11 @@ export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y]
       const values = facetsRef.current
 
       for (const value of values) {
-        if (value === NO_VALUE) return NO_VALUE
+        if (value === NO_VALUE) return defaultReturnValue != null ? defaultReturnValue : NO_VALUE
       }
 
       return callbackMemoized(...(values as ExtractFacetValues<T>))(...(args as K))
     },
-    [callbackMemoized, facetsRef],
+    [callbackMemoized, facetsRef, defaultReturnValue],
   )
 }


### PR DESCRIPTION
The motivation is to make it easier to use callbacks constructed via the hook `useFacetCallback` to interoperate with other libraries. 

As an example, before this change we will get a type error if we plan to use the resulting callback as a prop to a component that expects a string as a return type:

```
Type '() => string | unique symbol' is not assignable to type '() => string'.
  Type 'string | unique symbol' is not assignable to type 'string'.
    Type 'typeof import("c:/dev/minecraft-ui/node_modules/@react-facet/core/dist/types").NO_VALUE' is not assignable to type 'string'.ts(2322)
```

The new `defaultReturnValue` prop allow us to have a callback that can never return `NO_VALUE`.