### PR TITLE
Fix useFacetCallback mismatch subscriptions

### DIFF
--- a/packages/@react-facet/core/src/hooks/useFacetCallback.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.ts
@@ -46,7 +46,7 @@ export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y]
   useLayoutEffect(() => {
     // Make sure to start subscriptions, even though we are getting the values directly from them
     // We read the values using `.get` to make sure they are always up-to-date
-    const unsubscribes = facets.map((facet) => facet.observe(noop))
+    const unsubscribes = facets.map((facet) => facet.observe(() => {}))
 
     return () => {
       unsubscribes.forEach((unsubscribe) => unsubscribe())
@@ -74,5 +74,3 @@ export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y]
     [callbackMemoized, defaultReturnValue, ...facets],
   )
 }
-
-const noop = () => {}


### PR DESCRIPTION
After the fix of #114, it introduced a new bug that would cause the callback to never being able to be called since `useFacetCallback` would internally might no longer have a facet with an active subscription.

The new bug was caused by using a shared `noop` instance across all usages of `useFacetCallback`, and it occurs because our `createFacet` implementation uses a given listener instance as a key to keep track of all its listeners. See: https://github.com/Mojang/ore-ui/blob/main/packages/%40react-facet/core/src/facet/createFacet.ts#L17

The fix makes sure that we don't reuse the same instance, with a accompanying unit test.

In the future we might want to review our decision of using a `Set` as it can potentially introduce issues such as this one. There has been some work on this front, but it comes with other challenges as well (potentially [on performance](https://github.com/Mojang/ore-ui/pull/94) and [supporting unsubscribing as events are firing](https://github.com/Mojang/ore-ui/blob/main/packages/%40react-facet/core/src/facet/createFacet.spec.ts#L141)).