### PR TITLE
Do not mix data and methods in sharedSelector

### DIFF
--- a/packages/@react-facet/core/src/types.ts
+++ b/packages/@react-facet/core/src/types.ts
@@ -13,6 +13,15 @@ export interface EqualityCheck<T> {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Value = string | number | boolean | undefined | null | [] | Record<string, any>
 
+export type ValueWithoutFunction =
+  | string
+  | number
+  | boolean
+  | undefined
+  | null
+  | ValueWithoutFunction[]
+  | { [key: string]: ValueWithoutFunction }
+
 export type ExtractFacetValues<T extends ReadonlyArray<Facet<unknown>>> = {
   [K in keyof T]: T[K] extends Facet<infer V> ? V : never
 }

--- a/packages/@react-facet/shared-facet/src/safeSharedFacet.ts
+++ b/packages/@react-facet/shared-facet/src/safeSharedFacet.ts
@@ -1,6 +1,6 @@
 import memoize from './memoize'
 import { createFacet, NO_VALUE, Option, FACET_FACTORY } from '@react-facet/core'
-import { SharedFacetDriver, SharedFacet } from './types'
+import { SharedFacetDriver, SharedFacet, OnlyDataOrOnlyMethods } from './types'
 
 /**
  * Defines a facet with shared data
@@ -8,10 +8,10 @@ import { SharedFacetDriver, SharedFacet } from './types'
  * @param name the name of the facet (used to construct it with the sharedFacetDriver)
  * @param initialValue optional default value while constructor is not ready with the real value
  */
-/**
- * @deprecated use safeSharedFacet instead
- */
-export function sharedFacet<T>(name: string, initialValue: Option<T> = NO_VALUE): SharedFacet<T> {
+export function safeSharedFacet<T, R = OnlyDataOrOnlyMethods<T, false>>(
+  name: string,
+  initialValue: Option<T> = NO_VALUE,
+): SharedFacet<Readonly<R>> {
   const definition = memoize((sharedFacetDriver: SharedFacetDriver) =>
     createFacet<T>({
       initialValue,
@@ -19,7 +19,7 @@ export function sharedFacet<T>(name: string, initialValue: Option<T> = NO_VALUE)
         return sharedFacetDriver(name, update)
       },
     }),
-  ) as unknown as SharedFacet<T>
+  ) as unknown as SharedFacet<R>
 
   definition.factory = FACET_FACTORY
 

--- a/packages/@react-facet/shared-facet/src/safeSharedSelector.spec.ts
+++ b/packages/@react-facet/shared-facet/src/safeSharedSelector.spec.ts
@@ -1,0 +1,88 @@
+import { WritableFacet } from '@react-facet/core'
+import { safeSharedSelector } from './safeSharedSelector'
+import { safeSharedFacet } from './safeSharedFacet'
+
+interface TestFacet {
+  values: string[]
+}
+
+const sharedFacetDriver = jest.fn()
+
+describe('single dependency', () => {
+  it('does not fire without default value', () => {
+    const facet = safeSharedFacet<TestFacet>('my facet')
+    const mySelector = safeSharedSelector((testFacet) => testFacet, [facet])
+    const mock = jest.fn()
+    mySelector(sharedFacetDriver).observe(mock)
+    expect(mock).toHaveBeenCalledTimes(0)
+  })
+
+  it('fires when set without default value', () => {
+    const facet = safeSharedFacet<TestFacet>('my facet')
+    const writableFacet = facet(sharedFacetDriver) as WritableFacet<TestFacet>
+    const mySelector = safeSharedSelector((testFacet) => testFacet.values[0], [facet])
+    const mock = jest.fn()
+    mySelector(sharedFacetDriver).observe(mock)
+    expect(mock).toHaveBeenCalledTimes(0)
+    writableFacet.set({ values: ['new value'] })
+    expect(mock).toHaveBeenCalledTimes(1)
+    expect(mock).toHaveBeenCalledWith('new value')
+  })
+
+  it('fires with default value on dependency', () => {
+    const defaultValue = { values: ['default value'] }
+    const facet = safeSharedFacet<TestFacet>('my facet', defaultValue)
+    const mySelector = safeSharedSelector((testFacet) => testFacet.values[0], [facet])
+    const mock = jest.fn()
+    mySelector(sharedFacetDriver).observe(mock)
+    expect(mock).toHaveBeenCalledTimes(1)
+    expect(mock).toHaveBeenCalledWith('default value')
+  })
+})
+
+describe('array dependency', () => {
+  it('does not fire without default value', () => {
+    const facet = safeSharedFacet<TestFacet>('my facet')
+    const otherFacet = safeSharedFacet<TestFacet>('my other facet')
+    const mySelector = safeSharedSelector((testFacet) => testFacet, [facet, otherFacet])
+    const mock = jest.fn()
+    mySelector(sharedFacetDriver).observe(mock)
+    expect(mock).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not fire without default value on at least one', () => {
+    const facet = safeSharedFacet<TestFacet>('my facet')
+    const otherFacet = safeSharedFacet<TestFacet>('my other facet', { values: ['default value'] })
+    const mySelector = safeSharedSelector((testFacet) => testFacet, [facet, otherFacet])
+    const mock = jest.fn()
+    mySelector(sharedFacetDriver).observe(mock)
+    expect(mock).toHaveBeenCalledTimes(0)
+  })
+
+  it('does fire when triggered without default value', () => {
+    const facet = safeSharedFacet<TestFacet>('my facet')
+    const writableFacet = facet(sharedFacetDriver) as WritableFacet<TestFacet>
+    const otherFacet = safeSharedFacet<TestFacet>('other facet')
+    const writableOtherFacet = otherFacet(sharedFacetDriver) as WritableFacet<TestFacet>
+    const mySelector = safeSharedSelector((testFacet) => testFacet.values[0], [facet, otherFacet])
+    const mock = jest.fn()
+    mySelector(sharedFacetDriver).observe(mock)
+    writableFacet.set({ values: ['new value'] })
+    expect(mock).toHaveBeenCalledTimes(0)
+    writableOtherFacet.set({ values: ['other new value'] })
+    expect(mock).toHaveBeenCalledTimes(1)
+    expect(mock).toHaveBeenCalledWith('new value')
+  })
+
+  it('fires with default value on dependency', () => {
+    const defaultValue = { values: ['default value'] }
+    const otherDefaultValue = { values: ['other default value'] }
+    const facet = safeSharedFacet<TestFacet>('my facet', defaultValue)
+    const otherFacet = safeSharedFacet<TestFacet>('my other facet', otherDefaultValue)
+    const mySelector = safeSharedSelector((testFacet) => testFacet.values[0], [facet, otherFacet])
+    const mock = jest.fn()
+    mySelector(sharedFacetDriver).observe(mock)
+    expect(mock).toHaveBeenCalledTimes(1)
+    expect(mock).toHaveBeenCalledWith('default value')
+  })
+})

--- a/packages/@react-facet/shared-facet/src/safeSharedSelector.ts
+++ b/packages/@react-facet/shared-facet/src/safeSharedSelector.ts
@@ -1,6 +1,6 @@
 import memoize from './memoize'
-import { EqualityCheck, defaultEqualityCheck, mapFacetsCached, FACET_FACTORY, NoValue } from '@react-facet/core'
-import { SharedFacetDriver, SharedFacet } from './types'
+import { EqualityCheck, defaultEqualityCheck, mapFacetsCached, FACET_FACTORY } from '@react-facet/core'
+import { SharedFacetDriver, SharedFacet, OnlyDataOrOnlyMethods } from './types'
 
 /**
  * Defines a selector to transform/map data from a facet
@@ -17,15 +17,11 @@ import { SharedFacetDriver, SharedFacet } from './types'
  * returned by the selector are numbers, booleans, strings, or objects/arrays constructed by the selector.
  *
  * @param facets which facets to read the data from
- * @param selector a function to transform the data from the facets
+ * @param selector a function to transform the data from the facets. Do not mix data and methods.
  * @param equalityCheck optional, has a default for immutable values
  */
-/**
- * @deprecated use safeSharedSelector instead
- */
-export function sharedSelector<V, Y extends readonly SharedFacet<unknown>[], T extends [...Y]>(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  selector: (...args: { [K in keyof T]: T[K] extends SharedFacet<infer V> ? V : never }) => V | NoValue,
+export function safeSharedSelector<V, Y extends readonly SharedFacet<unknown>[], T extends [...Y]>(
+  selector: (...args: { [K in keyof T]: T[K] extends SharedFacet<infer V> ? V : never }) => OnlyDataOrOnlyMethods<V>,
   facets: T,
   equalityCheck: EqualityCheck<V> = defaultEqualityCheck,
 ): SharedFacet<V> {

--- a/packages/@react-facet/shared-facet/src/sharedFacet.ts
+++ b/packages/@react-facet/shared-facet/src/sharedFacet.ts
@@ -1,6 +1,6 @@
-import memoize from './memoize'
-import { createFacet, NO_VALUE, Option, FACET_FACTORY } from '@react-facet/core'
-import { SharedFacetDriver, SharedFacet } from './types'
+import { NO_VALUE, Option } from '@react-facet/core'
+import { SharedFacet } from './types'
+import { safeSharedFacet } from './safeSharedFacet'
 
 /**
  * Defines a facet with shared data
@@ -12,16 +12,5 @@ import { SharedFacetDriver, SharedFacet } from './types'
  * @deprecated use safeSharedFacet instead
  */
 export function sharedFacet<T>(name: string, initialValue: Option<T> = NO_VALUE): SharedFacet<T> {
-  const definition = memoize((sharedFacetDriver: SharedFacetDriver) =>
-    createFacet<T>({
-      initialValue,
-      startSubscription: (update) => {
-        return sharedFacetDriver(name, update)
-      },
-    }),
-  ) as unknown as SharedFacet<T>
-
-  definition.factory = FACET_FACTORY
-
-  return definition
+  return safeSharedFacet(name, initialValue)
 }

--- a/packages/@react-facet/shared-facet/src/sharedSelector.ts
+++ b/packages/@react-facet/shared-facet/src/sharedSelector.ts
@@ -1,6 +1,6 @@
 import memoize from './memoize'
-import { EqualityCheck, defaultEqualityCheck, mapFacetsCached, FACET_FACTORY, NoValue } from '@react-facet/core'
-import { SharedFacetDriver, SharedFacet } from './types'
+import { EqualityCheck, defaultEqualityCheck, mapFacetsCached, FACET_FACTORY } from '@react-facet/core'
+import { SharedFacetDriver, SharedFacet, OnlyDataOrOnlyMethods } from './types'
 
 /**
  * Defines a selector to transform/map data from a facet
@@ -17,12 +17,11 @@ import { SharedFacetDriver, SharedFacet } from './types'
  * returned by the selector are numbers, booleans, strings, or objects/arrays constructed by the selector.
  *
  * @param facets which facets to read the data from
- * @param selector a function to transform the data from the facets
+ * @param selector a function to transform the data from the facets. Do not mix data and methods.
  * @param equalityCheck optional, has a default for immutable values
  */
 export function sharedSelector<V, Y extends readonly SharedFacet<unknown>[], T extends [...Y]>(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  selector: (...args: { [K in keyof T]: T[K] extends SharedFacet<infer V> ? V : never }) => V | NoValue,
+  selector: (...args: { [K in keyof T]: T[K] extends SharedFacet<infer V> ? V : never }) => OnlyDataOrOnlyMethods<V>,
   facets: T,
   equalityCheck: EqualityCheck<V> = defaultEqualityCheck,
 ): SharedFacet<V> {

--- a/packages/@react-facet/shared-facet/src/sharedSelector.ts
+++ b/packages/@react-facet/shared-facet/src/sharedSelector.ts
@@ -1,6 +1,6 @@
-import memoize from './memoize'
-import { EqualityCheck, defaultEqualityCheck, mapFacetsCached, FACET_FACTORY, NoValue } from '@react-facet/core'
-import { SharedFacetDriver, SharedFacet } from './types'
+import { EqualityCheck, defaultEqualityCheck, NoValue } from '@react-facet/core'
+import { SharedFacet } from './types'
+import { safeSharedSelector } from './safeSharedSelector'
 
 /**
  * Defines a selector to transform/map data from a facet
@@ -24,20 +24,10 @@ import { SharedFacetDriver, SharedFacet } from './types'
  * @deprecated use safeSharedSelector instead
  */
 export function sharedSelector<V, Y extends readonly SharedFacet<unknown>[], T extends [...Y]>(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   selector: (...args: { [K in keyof T]: T[K] extends SharedFacet<infer V> ? V : never }) => V | NoValue,
   facets: T,
   equalityCheck: EqualityCheck<V> = defaultEqualityCheck,
 ): SharedFacet<V> {
-  const definition = memoize((sharedFacetDriver: SharedFacetDriver) =>
-    mapFacetsCached(
-      facets.map((facet) => facet(sharedFacetDriver)),
-      selector as (...args: unknown[]) => ReturnType<typeof selector>,
-      equalityCheck,
-    ),
-  ) as unknown as SharedFacet<V>
-
-  definition.factory = FACET_FACTORY
-
-  return definition
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return safeSharedSelector(selector as any, facets, equalityCheck)
 }

--- a/packages/@react-facet/shared-facet/src/types.ts
+++ b/packages/@react-facet/shared-facet/src/types.ts
@@ -27,12 +27,14 @@ export interface SharedFacet<T> extends FacetFactory<T> {
 }
 
 /**
- * This type act as a guard against mixing methods and data.
+ * This utility act as a guard against mixing methods and data.
  */
-export type OnlyDataOrOnlyMethods<T> = Flatten<T> extends (...args: never) => unknown
-  ? T | NoValue
+export type OnlyDataOrOnlyMethods<T, C = true, R = C extends true ? T | NoValue : T> = Flatten<T> extends (
+  ...args: never
+) => unknown
+  ? R
   : Flatten<T> extends ValueWithoutFunction
-  ? T | NoValue
+  ? R
   : never
 
 /**

--- a/packages/@react-facet/shared-facet/src/types.ts
+++ b/packages/@react-facet/shared-facet/src/types.ts
@@ -1,4 +1,6 @@
-import { Facet, FacetFactory } from '@react-facet/core'
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Facet, FacetFactory, NoValue, Value, ValueWithoutFunction } from '@react-facet/core'
 
 export interface OnChange<V> {
   (value: V): void
@@ -24,3 +26,21 @@ export interface SharedFacetDriver {
 export interface SharedFacet<T> extends FacetFactory<T> {
   (sharedFacetDriver: SharedFacetDriver): Facet<T>
 }
+
+export type OnlyDataOrOnlyMethods<T> = Flatten<T> extends (...args: never) => unknown
+  ? T | NoValue
+  : Flatten<T> extends ValueWithoutFunction
+  ? T | NoValue
+  : never
+
+type Flatten<T> = T extends object
+  ? T extends unknown[]
+    ? T[number] extends object
+      ? Flatten<T[number]>
+      : T[number]
+    : T extends (...args: never) => unknown
+    ? T
+    : T[keyof T] extends object
+    ? Flatten<T[keyof T]>
+    : T[keyof T]
+  : T

--- a/packages/@react-facet/shared-facet/src/types.ts
+++ b/packages/@react-facet/shared-facet/src/types.ts
@@ -36,7 +36,7 @@ export type OnlyDataOrOnlyMethods<T> = Flatten<T> extends (...args: never) => un
   : never
 
 /**
- * Utility to extract the value from a generic type
+ * Utility to extract values from a generic type
  */
 type Flatten<T> = T extends object
   ? T extends unknown[]

--- a/packages/@react-facet/shared-facet/src/types.ts
+++ b/packages/@react-facet/shared-facet/src/types.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { Facet, FacetFactory, NoValue, Value, ValueWithoutFunction } from '@react-facet/core'
+import { Facet, FacetFactory, NoValue, ValueWithoutFunction } from '@react-facet/core'
 
 export interface OnChange<V> {
   (value: V): void
@@ -27,12 +26,18 @@ export interface SharedFacet<T> extends FacetFactory<T> {
   (sharedFacetDriver: SharedFacetDriver): Facet<T>
 }
 
+/**
+ * This type act as a guard against mixing methods and data.
+ */
 export type OnlyDataOrOnlyMethods<T> = Flatten<T> extends (...args: never) => unknown
   ? T | NoValue
   : Flatten<T> extends ValueWithoutFunction
   ? T | NoValue
   : never
 
+/**
+ * Utility to extract the value from a generic type
+ */
 type Flatten<T> = T extends object
   ? T extends unknown[]
     ? T[number] extends object


### PR DESCRIPTION
As discussed on FE tech collab 2023-02-28

This PR propose a new type that ensures that the return type of the selector does not mix methods and data

- ✅ Only data 
<img width="989" alt="CleanShot 2023-03-06 at 14 26 14@2x" src="https://user-images.githubusercontent.com/1597781/223123021-3891b53c-bb65-48ee-be1b-8f349ce12f06.png">

- ✅ Only functions/methods
<img width="951" alt="CleanShot 2023-03-06 at 14 27 57@2x" src="https://user-images.githubusercontent.com/1597781/223123331-7178d973-e367-4d2f-b120-902a409040bc.png">

- 🛑 Mix data and methods
<img width="960" alt="CleanShot 2023-03-06 at 14 28 46@2x" src="https://user-images.githubusercontent.com/1597781/223123507-857aa0ba-c3b4-4051-ad28-b6aaeb5419c4.png">


## Discussion
- Should this be implemented in other hooks?


## Improvements
- I wish I could make the error clearer for the consumer.
<img width="1328" alt="CleanShot 2023-03-06 at 14 24 36@2x" src="https://user-images.githubusercontent.com/1597781/223122580-58a5a1f4-897d-4fd7-9a7f-f290fe161619.png">

