### PR TITLE
Update the list of maintainers in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open-source building blocks from Mojang Studios to construct video game user int
 
 This repository contains some infrastructure bits used internally, but that can also be shared across other game studios and general-purpose web applications.
 
-Current titles using this tech:
+Some of the projects using this tech are:
 
 - Minecraft Bedrock Edition
 - Minecraft Legends

--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 <img src="logo.png" width="400px" />
 
-Open-source building blocks from Mojang Studios to construct video game user interfaces (UI's) using web tech.
+Open-source building blocks from Mojang Studios to construct video game user interfaces (UI's) using [web standards](https://coherent-labs.com/products/coherent-gameface/).
 
 ## What is this?
 
-Minecraft Bedrock Edition is migrating its UI system to a solution based on [web standards](https://coherent-labs.com/products/coherent-gameface/). This repository contains some infrastructure bits used internally, but that can also be shared across other game studios and general-purpose web applications.
+This repository contains some infrastructure bits used internally, but that can also be shared across other game studios and general-purpose web applications.
+
+Current titles using this tech:
+
+- Minecraft Bedrock Edition
+- Minecraft Legends
 
 Ore UI is based on:
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <img src="logo.png" width="400px" />
 
-Open-source building blocks from Mojang Studios to construct game UIs using web tech.
+Open-source building blocks from Mojang Studios to construct video game user interfaces (UI's) using web tech.
 
 ## What is this?
 
 Minecraft Bedrock Edition is migrating its UI system to a solution based on [web standards](https://coherent-labs.com/products/coherent-gameface/). This repository contains some infrastructure bits used internally, but that can also be shared across other game studios and general-purpose web applications.
 
-The new system is based on:
+Ore UI is based on:
 
 - [React](https://reactjs.org/)
 - [TypeScript](https://www.typescriptlang.org/)
@@ -25,30 +25,66 @@ We currently only have one package that is open-source, and its documentation is
 
 The source of the documentation (for contributions) is available at the [documentation branch](https://github.com/Mojang/ore-ui/tree/documentation).
 
-## Team
+## Maintainers
+
+The repository is maintained by JavaScript developers at Mojang Studios.
 
 <table>
   <tbody>
     <tr>
       <td align="center" valign="top">
         <img width="150" height="150" src="https://github.com/pirelenito.png?s=150">
-        <br>
+        <br />
         <a href="https://github.com/pirelenito">Paulo Ragonha</a>
       </td>
       <td align="center" valign="top">
         <img width="150" height="150" src="https://github.com/xaviervia.png?s=150">
-        <br>
+        <br />
         <a href="https://github.com/xaviervia">Fernando Vía Canel</a>
       </td>
       <td align="center" valign="top">
         <img width="150" height="150" src="https://github.com/marlonicus.png?s=150">
-        <br>
+        <br />
         <a href="https://github.com/marlonicus">Marlon Huber-Smith</a>
       </td>
       <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/dderg.png?s=150">
-        <br>
-        <a href="https://github.com/dderg">Danila Dergachev</a>
+        <img width="150" height="150" src="https://github.com/hebbeh.png?s=150">
+        <br />
+        <a href="https://github.com/hebbeh">Anna Päärni</a>
+      </td>
+     </tr>
+    <tr>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/jacobbergdahl.png?s=150">
+        <br />
+        <a href="https://github.com/jacobbergdahl">Jacob Bergdahl</a>
+      </td>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/MartinMoe.png?s=150">
+        <br />
+        <a href="https://github.com/MartinMoe">Martin Moe</a>
+      </td>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/AdamRamberg.png?s=150">
+        <br />
+        <a href="https://github.com/AdamRamberg">Adam Ramberg</a>
+      </td>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/vb.png?s=150">
+        <br />
+        <a href="https://github.com/vb">Viktor Bergehall</a>
+      </td>
+     </tr>
+    <tr>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/Shenato.png?s=150">
+        <br />
+        <a href="https://github.com/Shenato">Omar ElGaml</a>
+      </td>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/ja-ni.png?s=150">
+        <br />
+        <a href="https://github.com/ja-ni">James Nicholls</a>
       </td>
      </tr>
   </tbody>
@@ -56,16 +92,4 @@ The source of the documentation (for contributions) is available at the [documen
 
 ## Logo
 
-**React Facet** and **Ore UI** logos designed by [Nekofresa](https://twitter.com/nekofresa).
-
-## Contributors
-
-<a href="https://github.com/Warwolt" target="_blank"><img width="42" height="42" src="https://github.com/Warwolt.png?s=42"></a>
-<a href="https://github.com/lucaslsf" target="_blank"><img width="42" height="42" src="https://github.com/lucaslsf.png?s=42"></a>
-<a href="https://github.com/volgar" target="_blank"><img width="42" height="42" src="https://github.com/volgar.png?s=42"></a>
-<a href="https://github.com/SleepyWerewolf" target="_blank"><img width="42" height="42" src="https://github.com/SleepyWerewolf.png?s=42"></a>
-<a href="https://github.com/Joslind" target="_blank"><img width="42" height="42" src="https://github.com/Joslind.png?s=42"></a>
-<a href="https://github.com/OskarPedersen" target="_blank"><img width="42" height="42" src="https://github.com/OskarPedersen.png?s=42"></a>
-<a href="https://github.com/pillimoj" target="_blank"><img width="42" height="42" src="https://github.com/pillimoj.png?s=42"></a>
-<a href="https://github.com/timlindeberg" target="_blank"><img width="42" height="42" src="https://github.com/timlindeberg.png?s=42"></a>
-<a href="https://github.com/adwenture" target="_blank"><img width="42" height="42" src="https://github.com/adwenture.png?s=42"></a>
+The **React Facet** and **Ore UI** logos are designed by [Nekofresa](https://twitter.com/nekofresa).


### PR DESCRIPTION
# Update the list of maintainers in the README.md file

We had a discussion in Core UI about how the list of maintainers in the `README.md` file has become outdated. This PR aims to update the list. I've made the following changes:

- "Team" has been renamed to "Maintainers", and now list all JS developers currently in Core UI, Menu UI, and Gameplay UI. The names are sorted by how long they've been at Mojang Studios.
- We have removed the section "Contributors", to instead just use Github's a [built-in feature](https://github.com/Mojang/ore-ui/graphs/contributors) for this.

Let me know if you have any thoughts about this and if there are any changes that you want to make!

Also, a friendly ping to @dderg who I could not tag as a reviewer.