### PR TITLE
Keep useFacetCallback instance same even if facets instances change

### DIFF
--- a/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
@@ -3,10 +3,9 @@ import { act, render } from '@react-facet/dom-fiber-testing-library'
 import { useFacetCallback } from './useFacetCallback'
 import { useFacetEffect } from './useFacetEffect'
 import { useFacetMap } from './useFacetMap'
-import { NO_VALUE } from '../types'
-import { createFacet } from '../facet'
+import { NO_VALUE, Facet } from '../types'
+import { createFacet, createStaticFacet } from '../facet'
 import { NoValue } from '..'
-import { createStaticFacet, Facet } from '@react-facet/core'
 
 it('captures the current value of the facet in a function that can be used as handler', () => {
   const demoFacet = createFacet({ initialValue: 'initial value' })

--- a/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
@@ -6,6 +6,7 @@ import { useFacetMap } from './useFacetMap'
 import { NO_VALUE } from '../types'
 import { createFacet } from '../facet'
 import { NoValue } from '..'
+import { createStaticFacet, Facet } from '@react-facet/core'
 
 it('captures the current value of the facet in a function that can be used as handler', () => {
   const demoFacet = createFacet({ initialValue: 'initial value' })
@@ -323,28 +324,29 @@ describe('regressions', () => {
   })
 
   it('always returns the same callback instance, even if the Facet instances change', () => {
-    let handler: (event: string) => void = () => {}
+    let handler: () => void = () => {}
+    const facetA = createStaticFacet('a')
+    const facetB = createStaticFacet('b')
 
-    const TestComponent = () => {
-      const facetA = createFacet<string>({ initialValue: 'a' })
-      const facetB = createFacet<string>({ initialValue: 'b' })
-
+    const TestComponent = ({ facet }: { facet: Facet<string> }) => {
       handler = useFacetCallback(
-        (a, b) => () => {
-          return a + b
+        (a) => () => {
+          return a
         },
         [],
-        [facetA, facetB],
+        [facet],
       )
 
       return null
     }
 
-    const { rerender } = render(<TestComponent />)
+    const { rerender } = render(<TestComponent facet={facetA} />)
     const firstHandler = handler
+    expect(firstHandler()).toBe('a')
 
-    rerender(<TestComponent />)
+    rerender(<TestComponent facet={facetB} />)
     const secondHandler = handler
+    expect(secondHandler()).toBe('b')
 
     expect(firstHandler).toBe(secondHandler)
   })

--- a/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
@@ -321,4 +321,6 @@ describe('regressions', () => {
       expect(result).toBe('valuestring')
     })
   })
+
+  it.todo('always returns the same callback instance, even if the Facet instances change')
 })

--- a/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
@@ -322,5 +322,30 @@ describe('regressions', () => {
     })
   })
 
-  it.todo('always returns the same callback instance, even if the Facet instances change')
+  it('always returns the same callback instance, even if the Facet instances change', () => {
+    let handler: (event: string) => void = () => {}
+
+    const TestComponent = () => {
+      const facetA = createFacet<string>({ initialValue: 'a' })
+      const facetB = createFacet<string>({ initialValue: 'b' })
+
+      handler = useFacetCallback(
+        (a, b) => () => {
+          return a + b
+        },
+        [],
+        [facetA, facetB],
+      )
+
+      return null
+    }
+
+    const { rerender } = render(<TestComponent />)
+    const firstHandler = handler
+
+    rerender(<TestComponent />)
+    const secondHandler = handler
+
+    expect(firstHandler).toBe(secondHandler)
+  })
 })

--- a/packages/@react-facet/core/src/hooks/useFacetCallback.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect } from 'react'
+import { useCallback, useLayoutEffect, useRef } from 'react'
 import { Facet, NO_VALUE, ExtractFacetValues, NoValue } from '../types'
 
 /**
@@ -59,8 +59,14 @@ export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y]
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const callbackMemoized = useCallback(callback, dependencies)
 
+  // Setup a ref so that the callback instance below can be kept the same
+  // when Facet instances change across re-renders
+  const facetsRef = useRef(facets)
+  facetsRef.current = facets
+
   return useCallback(
     (...args: K) => {
+      const facets = facetsRef.current
       const values = facets.map((facet) => facet.get())
 
       for (const value of values) {
@@ -69,8 +75,6 @@ export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y]
 
       return callbackMemoized(...(values as ExtractFacetValues<T>))(...(args as K))
     },
-    // We care about each individual facet and if any is a different reference
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [callbackMemoized, defaultReturnValue, ...facets],
+    [callbackMemoized, defaultReturnValue],
   )
 }


### PR DESCRIPTION
- This PR refactors the callback (`useCallback`) returned from `useFacetCallback`
- Previously, the callback had the facets (originally passed to `useFacetCallback`) in its dependency array, meaning it would return a new instance of the callback when the facets were modified
- This PR removes the facets from the dependency array and instead puts them in a ref.
- The callback then reads from the ref to get the current facet values