### PR TITLE
Use keys in map component - second try

### DIFF
--- a/examples/benchmarking/src/listMemoWithKeyFacet.tsx
+++ b/examples/benchmarking/src/listMemoWithKeyFacet.tsx
@@ -1,0 +1,110 @@
+import { useFacetState, Facet, useFacetMap, useFacetEffect, NO_VALUE, MapWithKey } from '@react-facet/core'
+import { render } from '@react-facet/dom-fiber'
+import React, { useEffect } from 'react'
+
+interface Data {
+  name: string
+  health: number
+  index: number
+}
+
+const initialData = Array.from({ length: 2000 }, (_, index): Data => ({ name: 'player', health: 10, index }))
+
+export const Performance = () => {
+  const [dataFacet, setDataFacet] = useFacetState(initialData)
+
+  useEffect(() => {
+    let frameId: number
+
+    const tick = () => {
+      setDataFacet((data) => {
+        if (data == NO_VALUE) return []
+
+        data[0].health = data[0].health === 10 ? 5 : 10
+        return data
+      })
+
+      frameId = requestAnimationFrame(tick)
+    }
+
+    tick()
+
+    return () => {
+      cancelAnimationFrame(frameId)
+    }
+  }, [setDataFacet])
+
+  return (
+    <>
+      <MapWithKey array={dataFacet} equalityCheck={dataEqualityCheck} keySelector={dataKeySelector}>
+        {(item) => <ListItem item={item} />}
+      </MapWithKey>
+    </>
+  )
+}
+
+const ListItem = ({ item }: { item: Facet<Data> }) => {
+  const health = useFacetMap((item) => item.health, [], [item])
+  const name = useFacetMap((item) => item.name, [], [item])
+
+  useFacetEffect(
+    (health) => {
+      randomWork(health)
+    },
+    [],
+    [health],
+  )
+
+  useFacetEffect(
+    (name) => {
+      randomWork(name)
+    },
+    [],
+    [name],
+  )
+
+  useFacetEffect(
+    (name) => {
+      randomWork(name)
+    },
+    [],
+    [name],
+  )
+
+  useFacetEffect(
+    (name) => {
+      randomWork(name)
+    },
+    [],
+    [name],
+  )
+
+  return null
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const randomWork = (name: string | number) => Math.random()
+
+const dataEqualityCheck = () => {
+  let previousName: string
+  let previousHealth: number
+  let previousIndex: number
+
+  return (current: Data) => {
+    if (current.name !== previousName || current.health !== previousHealth || current.index !== previousIndex) {
+      previousName = current.name
+      previousHealth = current.health
+      previousIndex = current.index
+      return false
+    }
+
+    return true
+  }
+}
+
+const dataKeySelector = (data: Data) => {
+  return data.name
+}
+
+document.body.innerHTML = '<div id="root"/>'
+render(<Performance />, document.getElementById('root'))

--- a/packages/@react-facet/core/src/components/MapWithKey.tsx
+++ b/packages/@react-facet/core/src/components/MapWithKey.tsx
@@ -1,0 +1,84 @@
+import React, { ReactElement, useRef, useState, memo, useMemo } from 'react'
+import { createFacet } from '../facet/createFacet'
+import { useFacetEffect } from '../hooks/useFacetEffect'
+import { EqualityCheck, Facet, NO_VALUE } from '../types'
+
+export type MapWithKeysProps<T> = {
+  array: Facet<T[]>
+  keySelector: (item: T) => React.Key
+  children: (item: Facet<T>, index: number) => ReactElement | null
+  equalityCheck?: EqualityCheck<T>
+}
+
+export const MapWithKey = <T,>({ array, children, keySelector, equalityCheck }: MapWithKeysProps<T>) => {
+  const currentKeys = useRef<React.Key[]>([])
+  const [, rerender] = useState(0)
+
+  useFacetEffect(
+    (array) => {
+      let shouldRerender = array.length != currentKeys.current.length
+      const newKeys = []
+
+      // Even though shouldRerender is true, we still need to loop through every item in the array
+      // in order to make sure no keys have changed and update previousKeys accordingly.
+      for (let i = 0; i < array.length; i++) {
+        const key = keySelector(array[i])
+        newKeys.push(key)
+
+        if (!shouldRerender && newKeys[i] !== currentKeys.current[i]) {
+          shouldRerender = true
+        }
+      }
+
+      if (shouldRerender) {
+        currentKeys.current = newKeys
+        rerender((value) => value + 1)
+      }
+    },
+    [keySelector],
+    [array],
+  )
+
+  const unwrappedArray = array.get()
+  if (unwrappedArray === NO_VALUE) return null
+
+  return (
+    <>
+      {unwrappedArray.map((item, index) => {
+        return (
+          <MemoizedMapChild
+            key={currentKeys.current[index]}
+            memoKey={currentKeys.current[index]}
+            index={index}
+            children={children as (item: Facet<unknown>, index: number) => ReactElement | null}
+            item={item}
+            equalityCheck={equalityCheck as EqualityCheck<unknown> | undefined}
+          />
+        )
+      })}
+    </>
+  )
+}
+
+type MapChildProps<T> = {
+  item: T
+  index: number
+  children: (item: Facet<T>, index: number) => ReactElement | null
+  equalityCheck?: EqualityCheck<T>
+  memoKey: React.Key
+}
+
+const MapChild = <T,>({ item, children, index, equalityCheck }: MapChildProps<T>) => {
+  const itemFacet = useMemo(
+    () => createFacet<T>({ initialValue: item, equalityCheck }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
+
+  return children(itemFacet, index)
+}
+
+const arePropsEqual = (oldProps: MapChildProps<unknown>, newProps: MapChildProps<unknown>) => {
+  return oldProps.memoKey === newProps.memoKey
+}
+const MemoizedMapChild = memo(MapChild, arePropsEqual)

--- a/packages/@react-facet/core/src/components/index.ts
+++ b/packages/@react-facet/core/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './Map'
+export * from './MapWithKey'
 export * from './Mount'
 export * from './With'


### PR DESCRIPTION
This PR makes #56 obsolete. 

Today the `<Map />` component is internally using the array index as a key when rendering out each item. This causes a similar problem to what is discussed in the [official React docs](https://reactjs.org/docs/lists-and-keys.html#keys). This PR introduces a prop called `keySelector`, which enables the consumer to select a unique key from the item data. If no [keySelector](url) is provided we default back to index as key.

In this PR we kept both implementations to be able to do a side-by-side comparison of the Map component: <Map /> (old) and `<MapWithKey />` (new)

# Benchmarking
When comparing the new implementation with the old one it seems to be quite a lot faster (36.7%).
### `yarn compare listMemoFacet listMemoState 70`
Iteration 0:    267302  509240  52.49%
Iteration 1:    245532  450027  54.56%
Iteration 2:    263251  440437  59.77%
Iteration 3:    232783  437802  53.17%
Iteration 4:    246622  425732  57.93%
Iteration 5:    219669  428715  51.24%
Iteration 6:    201011  459167  43.78%
Iteration 7:    259807  412293  63.02%
Iteration 8:    238269  436092  54.64%
Iteration 9:    283545  490877  57.76%
Relative performance listMemoFacet/listMemoState: 54.73

### `yarn compare listMemoWithKeyFacet listMemoState 70`
Iteration 0:    147970  415106  35.65%
Iteration 1:    136320  440923  30.92%
Iteration 2:    142283  417188  34.11%
Iteration 3:    151806  408697  37.14%
Iteration 4:    144983  427303  33.93%
Iteration 5:    139096  404501  34.39%
Iteration 6:    151532  429485  35.28%
Iteration 7:    129735  399111  32.51%
Iteration 8:    148728  412292  36.07%
Iteration 9:    146486  395972  36.99%
Relative performance listMemoWithKeyFacet/listMemoState: 34.67

# Discussion
- Should the `keySelector` prop be mandatory or optional? The best practice is not to use the array index as a key, but making it mandatory would be a breaking change
- Since this is a bug that only appears when adding/removing items that are not at end of the array (not that common use case), should we have two implementations? One where the array length is static (ie. could use the index as a key) and one dynamic
