### PR TITLE
Tweak hasDefinedValue typing

### DIFF
--- a/packages/@react-facet/core/src/helpers/hasDefinedValue.ts
+++ b/packages/@react-facet/core/src/helpers/hasDefinedValue.ts
@@ -1,3 +1,3 @@
 import { NoValue, NO_VALUE, Value } from '../types'
 
-export const hasDefinedValue = (value: Value | NoValue) => value != null && value !== NO_VALUE
+export const hasDefinedValue = (value: Value | NoValue): value is Value => value != null && value !== NO_VALUE


### PR DESCRIPTION
This PR improves the typing of the `hasDefinedValue` helper, narrowing the facet value type if it has a defined value.

Without this change, the type of the facet value after unwrapping is a union that includes `typeof NO_VALUE`, which is not assignable to `ReactNode`.

![Code_z2IIDDJfAr](https://user-images.githubusercontent.com/48810400/236708499-f94cdef8-fd43-413a-a12d-26ac512d038e.png)
