### PR TITLE
Adds support for custom equality checks on unwrap

### DIFF
--- a/packages/@react-facet/core/src/hooks/useFacetUnwrap.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetUnwrap.ts
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useState } from 'react'
-import { FacetProp, isFacet, Value, NoValue } from '../types'
+import { FacetProp, isFacet, Value, NoValue, EqualityCheck, NO_VALUE } from '../types'
+import { defaultEqualityCheck } from '../equalityChecks'
 
 /**
  * Hook that allows consuming values from a Facet
@@ -7,7 +8,10 @@ import { FacetProp, isFacet, Value, NoValue } from '../types'
  *
  * @param facet
  */
-export function useFacetUnwrap<T extends Value>(prop: FacetProp<T>): T | NoValue {
+export function useFacetUnwrap<T extends Value>(
+  prop: FacetProp<T>,
+  equalityCheck: EqualityCheck<T> = defaultEqualityCheck,
+): T | NoValue {
   const [state, setState] = useState<{ value: T | NoValue }>(() => {
     if (!isFacet(prop)) return { value: prop }
 
@@ -18,11 +22,16 @@ export function useFacetUnwrap<T extends Value>(prop: FacetProp<T>): T | NoValue
 
   useLayoutEffect(() => {
     if (isFacet(prop)) {
+      // Initialize the equalityCheck
+      const isEqual = equalityCheck()
+      const startValue = prop.get()
+      if (startValue !== NO_VALUE) {
+        isEqual(startValue)
+      }
+
       return prop.observe((value) => {
         setState((previousState) => {
           const { value: previousValue } = previousState
-
-          const typeofValue = typeof previousValue
 
           /**
            * Performs this equality check locally to prevent triggering two consecutive renderings
@@ -34,14 +43,24 @@ export function useFacetUnwrap<T extends Value>(prop: FacetProp<T>): T | NoValue
            * - Once on initialization of the useState above
            * - And another time on this observe initialization
            */
-          if (
-            (typeofValue === 'number' ||
-              typeofValue === 'string' ||
-              typeofValue === 'boolean' ||
-              value === undefined ||
-              value === null) &&
-            value === previousValue
-          ) {
+          if (equalityCheck === defaultEqualityCheck) {
+            const typeofValue = typeof previousValue
+
+            if (
+              (typeofValue === 'number' ||
+                typeofValue === 'string' ||
+                typeofValue === 'boolean' ||
+                value === undefined ||
+                value === null) &&
+              value === previousValue
+            ) {
+              return previousState
+            }
+
+            return { value }
+          }
+
+          if (previousValue !== NO_VALUE && isEqual(previousValue)) {
             return previousState
           }
 
@@ -49,7 +68,7 @@ export function useFacetUnwrap<T extends Value>(prop: FacetProp<T>): T | NoValue
         })
       })
     }
-  }, [prop])
+  }, [prop, equalityCheck])
 
   return isFacet(prop) ? state.value : prop
 }


### PR DESCRIPTION
Simple extension of the existing `useFacetUnwrap` API, allowing passing an optional extra argument to perform custom equality checks.

As its an optional argument, this is not breaking the current API contract.