### PR TITLE
Revert to using void as cleanup type for useFacetEffect

### DIFF
--- a/examples/benchmarking/src/listMemoFacet.tsx
+++ b/examples/benchmarking/src/listMemoFacet.tsx
@@ -50,7 +50,6 @@ const ListItem = ({ item }: { item: Facet<Data> }) => {
   useFacetEffect(
     (health) => {
       randomWork(health)
-      return undefined
     },
     [],
     [health],
@@ -59,7 +58,6 @@ const ListItem = ({ item }: { item: Facet<Data> }) => {
   useFacetEffect(
     (name) => {
       randomWork(name)
-      return undefined
     },
     [],
     [name],
@@ -68,7 +66,6 @@ const ListItem = ({ item }: { item: Facet<Data> }) => {
   useFacetEffect(
     (name) => {
       randomWork(name)
-      return undefined
     },
     [],
     [name],
@@ -77,7 +74,6 @@ const ListItem = ({ item }: { item: Facet<Data> }) => {
   useFacetEffect(
     (name) => {
       randomWork(name)
-      return undefined
     },
     [],
     [name],

--- a/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.spec.tsx
@@ -104,7 +104,6 @@ it('should work with uninitialized values', () => {
     useFacetEffect(
       () => {
         handler()
-        return undefined
       },
       [handler],
       [internalDemoFacet],

--- a/packages/@react-facet/core/src/hooks/useFacetEffect.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetEffect.spec.tsx
@@ -42,7 +42,6 @@ it('triggers the effect when a dependency changes', () => {
     useFacetEffect(
       (value) => {
         callback(`${value} ${dependency}`)
-        return undefined
       },
       [dependency],
       [demoFacet],

--- a/packages/@react-facet/core/src/hooks/useFacetEffect.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetEffect.tsx
@@ -4,7 +4,7 @@ import { cancelScheduledTask, scheduleTask } from '../scheduler'
 
 export const createUseFacetEffect = (useHook: typeof useEffect | typeof useLayoutEffect) => {
   return function <Y extends Facet<unknown>[], T extends [...Y]>(
-    effect: (...args: ExtractFacetValues<T>) => undefined | Cleanup,
+    effect: (...args: ExtractFacetValues<T>) => void | Cleanup,
     dependencies: unknown[],
     facets: T,
   ) {
@@ -12,7 +12,7 @@ export const createUseFacetEffect = (useHook: typeof useEffect | typeof useLayou
     const effectMemoized = useCallback(effect as (...args: unknown[]) => ReturnType<typeof effect>, dependencies)
 
     useHook(() => {
-      let cleanup: undefined | Cleanup
+      let cleanup: void | Cleanup
 
       if (facets.length === 1) {
         const unsubscribe = facets[0].observe((value) => {

--- a/packages/@react-facet/core/src/hooks/useFacetMap.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetMap.spec.tsx
@@ -105,7 +105,6 @@ describe('multiple dependencies', () => {
       useFacetEffect(
         (value) => {
           mock(value.name)
-          return undefined
         },
         [],
         [adaptValue],
@@ -148,7 +147,6 @@ describe('multiple dependencies', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],
@@ -191,7 +189,6 @@ describe('multiple dependencies', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],
@@ -234,7 +231,6 @@ describe('multiple dependencies', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],
@@ -392,7 +388,6 @@ describe('single dependency', () => {
       useFacetEffect(
         (value) => {
           mock(value.name)
-          return undefined
         },
         [],
         [adaptValue],
@@ -434,7 +429,6 @@ describe('single dependency', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],
@@ -476,7 +470,6 @@ describe('single dependency', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],
@@ -518,7 +511,6 @@ describe('single dependency', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],

--- a/packages/@react-facet/core/src/hooks/useFacetMemo.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetMemo.spec.tsx
@@ -105,7 +105,6 @@ describe('multiple dependencies', () => {
       useFacetEffect(
         (value) => {
           mock(value.name)
-          return undefined
         },
         [],
         [adaptValue],
@@ -148,7 +147,6 @@ describe('multiple dependencies', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],
@@ -191,7 +189,6 @@ describe('multiple dependencies', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],
@@ -234,7 +231,6 @@ describe('multiple dependencies', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],
@@ -392,7 +388,6 @@ describe('single dependency', () => {
       useFacetEffect(
         (value) => {
           mock(value.name)
-          return undefined
         },
         [],
         [adaptValue],
@@ -434,7 +429,6 @@ describe('single dependency', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],
@@ -476,7 +470,6 @@ describe('single dependency', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],
@@ -518,7 +511,6 @@ describe('single dependency', () => {
       useFacetEffect(
         (value) => {
           mock(value)
-          return undefined
         },
         [],
         [adaptValue],

--- a/packages/@react-facet/core/src/hooks/useFacetRef.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetRef.ts
@@ -14,7 +14,6 @@ export function useFacetRef<T>(facet: Facet<T>, defaultValue?: T): MutableRefObj
   useFacetEffect(
     (value) => {
       ref.current = value
-      return undefined
     },
     [],
     [facet],

--- a/packages/@react-facet/core/src/hooks/useFacetWrap.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetWrap.spec.tsx
@@ -14,7 +14,6 @@ it('wraps a value, updating the facet when it changes', () => {
     useFacetEffect(
       (value) => {
         mock(value)
-        return undefined
       },
       [],
       [facetifiedValue],
@@ -39,7 +38,6 @@ it('wraps a value, with the default equality check (preventing unnecessary updat
     useFacetEffect(
       (value) => {
         mock(value)
-        return undefined
       },
       [],
       [facetifiedValue],
@@ -64,7 +62,6 @@ it('forwards a facet', () => {
     useFacetEffect(
       (value) => {
         mock(value)
-        return undefined
       },
       [],
       [facetifiedValue],
@@ -125,7 +122,6 @@ const testEffectUpdatesOnStaticValue = (value: FacetProp<Value>, expectUpdates: 
     useFacetEffect(
       () => {
         mock()
-        return undefined
       },
       [],
       [undefinedFacet],


### PR DESCRIPTION
As @pirelenito noticed the change introduced in https://github.com/Mojang/ore-ui/pull/126 requires use of return undefined when using useFacetEffect. This PR fixes that issue.