### PR TITLE
Adding bigint to Value type

### DIFF
--- a/packages/@react-facet/core/src/types.ts
+++ b/packages/@react-facet/core/src/types.ts
@@ -11,7 +11,7 @@ export interface EqualityCheck<T> {
  * Currently functions are not supported
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Value = string | number | boolean | undefined | null | [] | Record<string, any>
+export type Value = string | number | boolean | undefined | null | [] | Record<string, any> | bigint
 
 export type ExtractFacetValues<T extends ReadonlyArray<Facet<unknown>>> = {
   [K in keyof T]: T[K] extends Facet<infer V> ? V : never


### PR DESCRIPTION
We use 64 bit handles for entities in our game engine which we pass to JS as bigints. We wish to make these handles into facets, thus we need them Value to include them.