### PR TITLE
Fixing incoming type errors from ts 5.1.3

### DIFF
--- a/packages/@react-facet/core/src/helpers/multiObserve.ts
+++ b/packages/@react-facet/core/src/helpers/multiObserve.ts
@@ -10,7 +10,7 @@ import { Facet, Unsubscribe, Cleanup, NO_VALUE, ExtractFacetValues } from '../ty
  * We pass the dependencies of the callback as the second argument so we can leverage the eslint-plugin-react-hooks option for additionalHooks.
  * Having this as the second argument allows the linter to work.
  */
-export function multiObserve<Y extends Facet<unknown>[], T extends [...Y]>(
+export function multiObserve<Y extends[Facet<unknown>, ...Facet<unknown>[]], T extends [...Y]>(
   effect: (...args: ExtractFacetValues<T>) => void | Cleanup,
   facets: T,
 ) {

--- a/packages/@react-facet/core/src/hooks/useFacetCallback.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetCallback.ts
@@ -13,7 +13,7 @@ import { Facet, NO_VALUE, ExtractFacetValues, NoValue } from '../types'
  * We pass the dependencies of the callback as the second argument so we can leverage the eslint-plugin-react-hooks option for additionalHooks.
  * Having this as the second argument allows the linter to work.
  */
-export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y], K extends [...unknown[]]>(
+export function useFacetCallback<M, Y extends[Facet<unknown>, ...Facet<unknown>[]], T extends [...Y], K extends [...unknown[]]>(
   callback: (...args: ExtractFacetValues<T>) => (...args: K) => M,
   dependencies: unknown[],
   facets: T,
@@ -31,13 +31,13 @@ export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y]
  * We pass the dependencies of the callback as the second argument so we can leverage the eslint-plugin-react-hooks option for additionalHooks.
  * Having this as the second argument allows the linter to work.
  */
-export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y], K extends [...unknown[]]>(
+export function useFacetCallback<M, Y extends[Facet<unknown>, ...Facet<unknown>[]], T extends [...Y], K extends [...unknown[]]>(
   callback: (...args: ExtractFacetValues<T>) => (...args: K) => M,
   dependencies: unknown[],
   facets: T,
 ): (...args: K) => M | NoValue
 
-export function useFacetCallback<M, Y extends Facet<unknown>[], T extends [...Y], K extends [...unknown[]]>(
+export function useFacetCallback<M, Y extends[Facet<unknown>, ...Facet<unknown>[]], T extends [...Y], K extends [...unknown[]]>(
   callback: (...args: ExtractFacetValues<T>) => (...args: K) => M,
   dependencies: unknown[],
   facets: T,

--- a/packages/@react-facet/core/src/hooks/useFacetEffect.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetEffect.tsx
@@ -3,7 +3,7 @@ import { Facet, Unsubscribe, Cleanup, NO_VALUE, ExtractFacetValues } from '../ty
 import { cancelScheduledTask, scheduleTask } from '../scheduler'
 
 export const createUseFacetEffect = (useHook: typeof useEffect | typeof useLayoutEffect) => {
-  return function <Y extends Facet<unknown>[], T extends [...Y]>(
+  return function <Y extends[Facet<unknown>, ...Facet<unknown>[]], T extends [...Y]>(
     effect: (...args: ExtractFacetValues<T>) => void | Cleanup,
     dependencies: unknown[],
     facets: T,

--- a/packages/@react-facet/core/src/hooks/useFacetMap.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetMap.ts
@@ -16,7 +16,7 @@ import { EqualityCheck, Facet, NoValue, ExtractFacetValues } from '../types'
  *
  * @returns a new facet definition that can be consumed as a regular facet
  */
-export function useFacetMap<M, Y extends Facet<unknown>[], T extends [...Y]>(
+export function useFacetMap<M, Y extends[Facet<unknown>, ...Facet<unknown>[]], T extends [...Y]>(
   selector: (...args: ExtractFacetValues<T>) => M | NoValue,
   dependencies: unknown[],
   facets: T,

--- a/packages/@react-facet/core/src/hooks/useFacetMemo.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetMemo.ts
@@ -16,7 +16,7 @@ import { EqualityCheck, Facet, NoValue, ExtractFacetValues } from '../types'
  *
  * @returns a new facet definition that can be consumed as a regular facet
  */
-export function useFacetMemo<M, Y extends Facet<unknown>[], T extends [...Y]>(
+export function useFacetMemo<M, Y extends[Facet<unknown>, ...Facet<unknown>[]], T extends [...Y]>(
   selector: (...args: ExtractFacetValues<T>) => M | NoValue,
   dependencies: unknown[],
   facets: T,

--- a/packages/@react-facet/core/src/types.ts
+++ b/packages/@react-facet/core/src/types.ts
@@ -11,7 +11,7 @@ export interface EqualityCheck<T> {
  * Currently functions are not supported
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Value = string | number | boolean | undefined | null | [] | Record<string, any>
+export type Value = string | number | boolean | undefined | null | [] | Record<string, any> | bigint
 
 export type ExtractFacetValues<T extends ReadonlyArray<Facet<unknown>>> = {
   [K in keyof T]: T[K] extends Facet<infer V> ? V : never


### PR DESCRIPTION
After updating to TS 5.1.3 the behavior of type inference of array types looks to have changed. Previously the types of a useFacetMap for example would look like so: `useFacetMap((a: number, b: string, c: boolean)=>{...},[...],[A: Facet<number>, B: Facet<string>, C: Facet<boolean])` After 5.1.3 the types look like so: `useFacetMap((a: number | string | boolean, b: number |string | boolean, c: number | string | boolean)=>{...},[...],[A: Facet<number>, B: Facet<string>, C: Facet<boolean>])` The selector arguments are infered as the union of the types of all passed in Facets, rather than each arguments type corresponding to their Facet's inner type. This change fixes that issue by explicitly making the array type we were previously extending into a tuple type. This allows TS to correctly infer the arguments' types.