### PR TITLE
Fix <With /> children being called with null|undefined

### DIFF
--- a/packages/@react-facet/core/src/components/With.tsx
+++ b/packages/@react-facet/core/src/components/With.tsx
@@ -1,19 +1,23 @@
 import { ReactElement } from 'react'
+import { useFacetMemo } from '../hooks/useFacetMemo'
 import { useFacetUnwrap } from '../hooks/useFacetUnwrap'
 import { useFacetMap } from '../hooks/useFacetMap'
-import { Facet, NoValue } from '../types'
+import { Facet, NO_VALUE } from '../types'
 
 type WithProps<T> = {
   data: Facet<T | null | undefined>
   children: (data: Facet<T>) => ReactElement | null
 }
 
-const hasData = <T,>(_: Facet<T | null | undefined>, shouldRender: boolean | NoValue): _ is Facet<T> => {
-  return shouldRender === true
-}
-
+/**
+ * Conditionally renders a child if a given facet value is not null or undefined
+ *
+ * @param data facet value which can be null or undefined
+ * @param children render prop which receives the transformed facet
+ */
 export const With = <T,>({ data, children }: WithProps<T>) => {
   const shouldRenderFacet = useFacetMap((data) => data !== null && data !== undefined, [], [data])
   const shouldRender = useFacetUnwrap(shouldRenderFacet)
-  return hasData(data, shouldRender) ? children(data) : null
+  const nonNullData = useFacetMemo((data) => (data !== null && data !== undefined ? data : NO_VALUE), [], [data])
+  return shouldRender === true ? children(nonNullData) : null
 }


### PR DESCRIPTION
## Problem

If `data` passed into a `<With />` component goes from a non-null value to a null value, then the child can be erroneously called with the null value.

## Solution

By preventing propagation using `NO_VALUE` we can ensure that the children will never be called with a null value.