### PR TITLE
Added property count to Map to make length of provided array available

### DIFF
--- a/packages/@react-facet/core/src/components/Map.spec.tsx
+++ b/packages/@react-facet/core/src/components/Map.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { act, render } from '@react-facet/dom-fiber-testing-library'
+import { act, getByTestId, render } from '@react-facet/dom-fiber-testing-library'
 import { createFacet } from '../facet'
 import { Facet } from '../types'
 import { useFacetEffect, useFacetMap } from '../hooks'
@@ -34,7 +34,7 @@ it('renders all items in a Facet of array', () => {
   const Example = () => {
     return (
       <Map array={data} equalityCheck={inputEqualityCheck}>
-        {(item, index) => <ExampleContent item={item} index={index} />}
+        {(item, index, count) => <ExampleContent item={item} index={index} />}
       </Map>
     )
   }
@@ -103,9 +103,9 @@ it('updates only items that have changed', () => {
 
   const mock = jest.fn()
 
-  const ExampleContent = ({ item }: { item: Facet<Input> }) => {
+  const ExampleContent = ({ item, count }: { item: Facet<Input>; count: number }) => {
     useFacetEffect(mock, [], [item])
-    return null
+    return <div data-testId={'count'}>{count}</div>
   }
 
   const inputEqualityCheck = () => {
@@ -125,14 +125,14 @@ it('updates only items that have changed', () => {
   const Example = () => {
     return (
       <Map array={data} equalityCheck={inputEqualityCheck}>
-        {(item) => <ExampleContent item={item} />}
+        {(item, count) => <ExampleContent item={item} count={count} />}
       </Map>
     )
   }
 
   const scenario = <Example />
 
-  render(scenario)
+  const { getByTestId } = render(scenario)
 
   expect(mock).toHaveBeenCalledTimes(5)
 
@@ -144,4 +144,25 @@ it('updates only items that have changed', () => {
 
   expect(mock).toHaveBeenCalledTimes(1)
   expect(mock).toHaveBeenCalledWith({ a: '6' })
+})
+
+it('count returns length of provided array', () => {
+  const data = createFacet({
+    initialValue: [{ a: '1' }, { a: '2' }, { a: '3' }],
+  })
+
+  const mock = jest.fn()
+
+  const ExampleContent = ({ index, count }: { index: number; count: number }) => {
+    return <>{count === index + 1 && <div data-testid={'count'}>{count}</div>}</>
+  }
+
+  const Example = () => {
+    return <Map array={data}>{(_, index, count) => <ExampleContent index={index} count={count} />}</Map>
+  }
+
+  const { getByTestId } = render(<Example />)
+
+  const counter = getByTestId('count')
+  expect(counter).toHaveTextContent('3')
 })

--- a/packages/@react-facet/core/src/components/Map.tsx
+++ b/packages/@react-facet/core/src/components/Map.tsx
@@ -6,12 +6,13 @@ import { EqualityCheck, Facet, NO_VALUE } from '../types'
 
 export type MapProps<T> = {
   array: Facet<T[]>
-  children: (item: Facet<T>, index: number) => ReactElement | null
+  children: (item: Facet<T>, index: number, count: number) => ReactElement | null
   equalityCheck?: EqualityCheck<T>
 }
 
 export const Map = <T,>({ array, children, equalityCheck }: MapProps<T>) => {
-  const countValue = useFacetUnwrap(useFacetMap((array) => array.length, [], [array])) ?? 0
+  const countValue = useFacetUnwrap(useFacetMap((array) => array.length, [], [array]))
+  const countNumber = countValue !== NO_VALUE ? countValue : 0
 
   return (
     <>
@@ -22,13 +23,14 @@ export const Map = <T,>({ array, children, equalityCheck }: MapProps<T>) => {
               key={index}
               arrayFacet={array}
               index={index}
+              count={countNumber}
               equalityCheck={equalityCheck}
               children={children}
             />
           ) : (
-            <MapChild<T> key={index} arrayFacet={array} index={index} children={children} />
+            <MapChild<T> key={index} arrayFacet={array} index={index} count={countNumber} children={children} />
           ),
-        countValue !== NO_VALUE ? countValue : 0,
+        countNumber,
       )}
     </>
   )
@@ -37,11 +39,12 @@ export const Map = <T,>({ array, children, equalityCheck }: MapProps<T>) => {
 type MapChildMemoProps<T> = {
   arrayFacet: Facet<T[]>
   index: number
-  children: (item: Facet<T>, index: number) => ReactElement | null
+  count: number
+  children: (item: Facet<T>, index: number, count: number) => ReactElement | null
   equalityCheck: EqualityCheck<T>
 }
 
-const MapChildMemo = <T,>({ arrayFacet, index, children, equalityCheck }: MapChildMemoProps<T>) => {
+const MapChildMemo = <T,>({ arrayFacet, index, count, children, equalityCheck }: MapChildMemoProps<T>) => {
   const childFacet = useFacetMemo(
     (array) => {
       if (index < array.length) return array[index]
@@ -51,16 +54,17 @@ const MapChildMemo = <T,>({ arrayFacet, index, children, equalityCheck }: MapChi
     [arrayFacet],
     equalityCheck,
   )
-  return children(childFacet, index)
+  return children(childFacet, index, count)
 }
 
 type MapChildProps<T> = {
   arrayFacet: Facet<T[]>
   index: number
-  children: (item: Facet<T>, index: number) => ReactElement | null
+  count: number
+  children: (item: Facet<T>, index: number, count: number) => ReactElement | null
 }
 
-const MapChild = <T,>({ arrayFacet, index, children }: MapChildProps<T>) => {
+const MapChild = <T,>({ arrayFacet, index, count, children }: MapChildProps<T>) => {
   const childFacet = useFacetMap(
     (array) => {
       if (index < array.length) return array[index]
@@ -70,7 +74,7 @@ const MapChild = <T,>({ arrayFacet, index, children }: MapChildProps<T>) => {
     [arrayFacet],
   )
 
-  return children(childFacet, index)
+  return children(childFacet, index, count)
 }
 
 interface TimesFn<T> {


### PR DESCRIPTION
`Map` now provides the child property `count` to allow consumers use the array length without requiring unwrap.