### PR TITLE
Cached maps (useFacetMemo) can return values before any subscription

### DIFF
--- a/packages/@react-facet/core/src/mapFacets/mapFacetArrayLightweight.ts
+++ b/packages/@react-facet/core/src/mapFacets/mapFacetArrayLightweight.ts
@@ -8,11 +8,11 @@ export function mapFacetArrayLightweight<M>(
 ): Facet<M> {
   return {
     get: () => {
-      const values = facets.map((facet) => facet.get())
-      const hasAllValues = values.reduce<boolean>((acc, value) => acc && value !== NO_VALUE, true)
+      const dependencyValues = facets.map((facet) => facet.get())
+      const hasAllValues = dependencyValues.reduce<boolean>((acc, value) => acc && value !== NO_VALUE, true)
       if (!hasAllValues) return NO_VALUE
 
-      return fn(...values)
+      return fn(...dependencyValues)
     },
     observe: mapIntoObserveArray(facets, fn, equalityCheck),
   }

--- a/packages/@react-facet/core/src/mapFacets/mapFacetSingleCached.ts
+++ b/packages/@react-facet/core/src/mapFacets/mapFacetSingleCached.ts
@@ -3,13 +3,28 @@ import { mapIntoObserveSingle } from './mapIntoObserveSingle'
 import { createFacet } from '../facet'
 
 export function mapFacetSingleCached<T, M>(
-  facets: Facet<T>,
+  facet: Facet<T>,
   fn: (value: T) => M | NoValue,
   equalityCheck?: EqualityCheck<M>,
 ): Facet<M> {
-  return createFacet<M>({
+  const cachedFacet = createFacet<M>({
     // pass the equalityCheck to the mapIntoObserveSingle to prevent even triggering the observable
-    startSubscription: mapIntoObserveSingle(facets, fn, equalityCheck),
+    startSubscription: mapIntoObserveSingle(facet, fn, equalityCheck),
     initialValue: NO_VALUE,
   })
+
+  return {
+    get: () => {
+      const cachedValue = cachedFacet.get()
+      if (cachedValue !== NO_VALUE) return cachedValue
+
+      const dependencyValue = facet.get()
+      if (dependencyValue === NO_VALUE) return NO_VALUE
+
+      const mappedValue = fn(dependencyValue)
+      if (mappedValue !== NO_VALUE) cachedFacet.set(mappedValue)
+      return mappedValue
+    },
+    observe: cachedFacet.observe,
+  }
 }

--- a/packages/@react-facet/core/src/mapFacets/mapFacetSingleLightweight.ts
+++ b/packages/@react-facet/core/src/mapFacets/mapFacetSingleLightweight.ts
@@ -8,10 +8,10 @@ export function mapFacetSingleLightweight<T, M>(
 ): Facet<M> {
   return {
     get: () => {
-      const value = facet.get()
-      if (value === NO_VALUE) return NO_VALUE
+      const dependencyValue = facet.get()
+      if (dependencyValue === NO_VALUE) return NO_VALUE
 
-      return fn(value)
+      return fn(dependencyValue)
     },
 
     observe: mapIntoObserveSingle(facet, fn, equalityCheck),

--- a/packages/@react-facet/core/src/mapFacets/mapFacets.spec.ts
+++ b/packages/@react-facet/core/src/mapFacets/mapFacets.spec.ts
@@ -63,7 +63,7 @@ describe('mapFacetsCached', () => {
     expect(mapFacet.get()).toBe('dummy')
   })
 
-  it('caches calls to the mapFunction though a get call before any subscription, given a single source', () => {
+  it('caches calls to the mapFunction through a get call before any subscription, given a single source', () => {
     const mapFunction = jest.fn().mockReturnValue('dummy')
     const sourceFacet = createFacet({ initialValue: 'initial value' })
     const mapFacet = mapFacetsCached([sourceFacet], mapFunction, () => () => false)

--- a/packages/@react-facet/core/src/mapFacets/mapFacets.spec.ts
+++ b/packages/@react-facet/core/src/mapFacets/mapFacets.spec.ts
@@ -76,7 +76,7 @@ describe('mapFacetsCached', () => {
     expect(mapFunction).not.toHaveBeenCalled()
   })
 
-  it('caches calls to the mapFunction though a get call before any subscription, given multiple sources', () => {
+  it('caches calls to the mapFunction through a get call before any subscription, given multiple sources', () => {
     const mapFunction = jest.fn().mockReturnValue('dummy')
     const sourceAFacet = createFacet({ initialValue: 'initial value' })
     const sourceBFacet = createFacet({ initialValue: 'initial value' })

--- a/packages/@react-facet/core/src/mapFacets/mapFacets.spec.ts
+++ b/packages/@react-facet/core/src/mapFacets/mapFacets.spec.ts
@@ -29,21 +29,65 @@ describe('mapFacetsCached', () => {
     expect(mapFunction).toHaveBeenCalledTimes(1)
   })
 
-  it('gets NO_VALUE as a value from a single source before any subscription', () => {
+  it('gets NO_VALUE as a value from a single source if it also has NO_VALUE', () => {
     const mapFunction = jest.fn().mockReturnValue('dummy')
-    const sourceFacet = createFacet({ initialValue: 'initial value' })
+    const sourceFacet = createFacet({ initialValue: NO_VALUE })
     const mapFacet = mapFacetsCached([sourceFacet], mapFunction, () => () => false)
 
     expect(mapFacet.get()).toBe(NO_VALUE)
   })
 
-  it('gets NO_VALUE as a value from multiple sources before any subscription', () => {
+  it('gets NO_VALUE as a value from multiple sources if they also have NO_VALUE', () => {
+    const mapFunction = jest.fn().mockReturnValue('dummy')
+    const sourceAFacet = createFacet({ initialValue: 'initial value' })
+    const sourceBFacet = createFacet({ initialValue: NO_VALUE })
+    const mapFacet = mapFacetsCached([sourceAFacet, sourceBFacet], mapFunction, () => () => false)
+
+    expect(mapFacet.get()).toBe(NO_VALUE)
+  })
+
+  it('can get the mapped value from a single source before any subscription', () => {
+    const mapFunction = jest.fn().mockReturnValue('dummy')
+    const sourceFacet = createFacet({ initialValue: 'initial value' })
+    const mapFacet = mapFacetsCached([sourceFacet], mapFunction, () => () => false)
+
+    expect(mapFacet.get()).toBe('dummy')
+  })
+
+  it('can get the mapped value from multiple sources before any subscription', () => {
     const mapFunction = jest.fn().mockReturnValue('dummy')
     const sourceAFacet = createFacet({ initialValue: 'initial value' })
     const sourceBFacet = createFacet({ initialValue: 'initial value' })
     const mapFacet = mapFacetsCached([sourceAFacet, sourceBFacet], mapFunction, () => () => false)
 
-    expect(mapFacet.get()).toBe(NO_VALUE)
+    expect(mapFacet.get()).toBe('dummy')
+  })
+
+  it('caches calls to the mapFunction though a get call before any subscription, given a single source', () => {
+    const mapFunction = jest.fn().mockReturnValue('dummy')
+    const sourceFacet = createFacet({ initialValue: 'initial value' })
+    const mapFacet = mapFacetsCached([sourceFacet], mapFunction, () => () => false)
+
+    expect(mapFacet.get()).toBe('dummy')
+    expect(mapFunction).toHaveBeenCalledTimes(1)
+
+    mapFunction.mockClear()
+    expect(mapFacet.get()).toBe('dummy')
+    expect(mapFunction).not.toHaveBeenCalled()
+  })
+
+  it('caches calls to the mapFunction though a get call before any subscription, given multiple sources', () => {
+    const mapFunction = jest.fn().mockReturnValue('dummy')
+    const sourceAFacet = createFacet({ initialValue: 'initial value' })
+    const sourceBFacet = createFacet({ initialValue: 'initial value' })
+    const mapFacet = mapFacetsCached([sourceAFacet, sourceBFacet], mapFunction, () => () => false)
+
+    expect(mapFacet.get()).toBe('dummy')
+    expect(mapFunction).toHaveBeenCalledTimes(1)
+
+    mapFunction.mockClear()
+    expect(mapFacet.get()).toBe('dummy')
+    expect(mapFunction).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
The choice of  `useFacetMap` or `useFacetMemo` should be based on performance metrics and what is best for each use-case. So, they should share as much as possible in terms of behaviour and API.

Currently, there is one small difference between then into how they handle attempts to read their values via a `get` before any subscription has started. 

With `useFacetMap`, because it has no internal caching, it always reads the source data when attempting to read its value through a `get`, so it would be possible to get the transformed mapped value even if no subscriptions were started.

However, with `useFacetMemo` because it has a cached value, it would always just return that value instead. Meaning you could get an innitial `NO_VALUE` with `useFacetMemo` when you would get the actual value with `useFacetMap`.

This PR fixes this inconsistency, so both hooks behave the same when trying to read their values ahead of any subscription.