### PR TITLE
Fix useFacetUnwrap support for custom equality check

### DIFF
--- a/packages/@react-facet/core/src/hooks/useFacetUnwrap.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetUnwrap.spec.tsx
@@ -219,7 +219,7 @@ it('does not trigger a re-render when changing a facet from undefined to undefin
 })
 
 it('supports custom equality checks', () => {
-  const value = {}
+  const value = { prop: 'initial' }
   const demoFacet = createFacet({ initialValue: value })
 
   // Dummy equality check that always returns its not equal
@@ -257,5 +257,19 @@ it('supports custom equality checks', () => {
   expect(equalityCheck).toHaveBeenCalledTimes(0) // equality check was already initialized
   expect(check).toHaveBeenCalledTimes(1) // but the check should be executed
   expect(check).toHaveBeenCalledWith(value) // passing the value (which should be the same)
+  expect(renderedMock).toHaveBeenCalledTimes(1) // and since the equality check always returns "false", we have a render
+
+  jest.clearAllMocks()
+
+  const newValue = { prop: 'new' }
+
+  // If we update with a new object,
+  act(() => {
+    demoFacet.set(newValue)
+  })
+
+  expect(equalityCheck).toHaveBeenCalledTimes(0) // equality check was already initialized
+  expect(check).toHaveBeenCalledTimes(1) // but the check should be executed
+  expect(check).toHaveBeenCalledWith(newValue) // passing the new value
   expect(renderedMock).toHaveBeenCalledTimes(1) // and since the equality check always returns "false", we have a render
 })

--- a/packages/@react-facet/core/src/hooks/useFacetUnwrap.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetUnwrap.ts
@@ -60,7 +60,7 @@ export function useFacetUnwrap<T extends Value>(
             return { value }
           }
 
-          if (previousValue !== NO_VALUE && isEqual(previousValue)) {
+          if (previousValue !== NO_VALUE && isEqual(value)) {
             return previousState
           }
 

--- a/packages/@react-facet/core/src/hooks/useFacetUnwrap.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetUnwrap.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import { FacetProp, isFacet, Value, NoValue, EqualityCheck, NO_VALUE } from '../types'
 import { defaultEqualityCheck } from '../equalityChecks'
 
@@ -12,12 +12,15 @@ export function useFacetUnwrap<T extends Value>(
   prop: FacetProp<T>,
   equalityCheck: EqualityCheck<T> = defaultEqualityCheck,
 ): T | NoValue {
+  const previousStateRef = useRef<T | NoValue>(NO_VALUE)
+
   const [state, setState] = useState<{ value: T | NoValue }>(() => {
     if (!isFacet(prop)) return { value: prop }
 
-    return {
-      value: prop.get(),
-    }
+    const value = prop.get()
+    previousStateRef.current = value
+
+    return { value }
   })
 
   useLayoutEffect(() => {
@@ -30,42 +33,42 @@ export function useFacetUnwrap<T extends Value>(
       }
 
       return prop.observe((value) => {
-        setState((previousState) => {
-          const { value: previousValue } = previousState
+        const previousValue = previousStateRef.current
+        previousStateRef.current = value
 
-          /**
-           * Performs this equality check locally to prevent triggering two consecutive renderings
-           * for facets that have immutable values (unfortunately we can't handle mutable values).
-           *
-           * The two renderings might happen for the same state value if the Facet has a value on mount.
-           *
-           * The unwrap will get the value:
-           * - Once on initialization of the useState above
-           * - And another time on this observe initialization
-           */
-          if (equalityCheck === defaultEqualityCheck) {
-            const typeofValue = typeof previousValue
+        /**
+         * Performs this equality check locally to prevent triggering two consecutive renderings
+         * for facets that have immutable values (unfortunately we can't handle mutable values).
+         *
+         * The two renderings might happen for the same state value if the Facet has a value on mount.
+         *
+         * The unwrap will get the value:
+         * - Once on initialization of the useState above
+         * - And another time on this observe initialization
+         */
+        if (equalityCheck === defaultEqualityCheck) {
+          const typeofValue = typeof previousValue
 
-            if (
-              (typeofValue === 'number' ||
-                typeofValue === 'string' ||
-                typeofValue === 'boolean' ||
-                value === undefined ||
-                value === null) &&
-              value === previousValue
-            ) {
-              return previousState
-            }
-
-            return { value }
+          if (
+            (typeofValue === 'number' ||
+              typeofValue === 'string' ||
+              typeofValue === 'boolean' ||
+              value === undefined ||
+              value === null) &&
+            value === previousValue
+          ) {
+            return
           }
 
-          if (previousValue !== NO_VALUE && isEqual(value)) {
-            return previousState
-          }
+          setState({ value })
+          return
+        }
 
-          return { value }
-        })
+        if (previousValue !== NO_VALUE && isEqual(value)) {
+          return
+        }
+
+        setState({ value })
       })
     }
   }, [prop, equalityCheck])


### PR DESCRIPTION
Custom equality checks for the `useFacetUnwrap` never worked, and instead would always consider the value to never change.