### PR TITLE
Correctly export fireEvent from renderer.ts

### DIFF
--- a/packages/@react-facet/dom-fiber-testing-library/src/renderer.ts
+++ b/packages/@react-facet/dom-fiber-testing-library/src/renderer.ts
@@ -239,3 +239,4 @@ export const act = environment.act
 export const render = environment.render
 export const cleanup = environment.cleanup
 export * from '@testing-library/dom'
+export const fireEvent = environment.fireEvent

--- a/packages/@react-facet/dom-fiber-testing-library/src/renderer.ts
+++ b/packages/@react-facet/dom-fiber-testing-library/src/renderer.ts
@@ -234,9 +234,13 @@ export type RenderResult = {
 
 type ContainerRootFiberTuple = [HTMLElement, FacetFiberRoot]
 
+// Destructure all exports except `fireEvent`
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { fireEvent: _, ...testingLibraryExcludingFireEvent } = testingLibrary
+export default testingLibraryExcludingFireEvent
+
 const environment = setup()
 export const act = environment.act
 export const render = environment.render
 export const cleanup = environment.cleanup
-export * from '@testing-library/dom'
 export const fireEvent = environment.fireEvent

--- a/packages/@react-facet/dom-fiber-testing-library/src/renderer.ts
+++ b/packages/@react-facet/dom-fiber-testing-library/src/renderer.ts
@@ -234,13 +234,11 @@ export type RenderResult = {
 
 type ContainerRootFiberTuple = [HTMLElement, FacetFiberRoot]
 
-// Destructure all exports except `fireEvent`
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const { fireEvent: _, ...testingLibraryExcludingFireEvent } = testingLibrary
-export default testingLibraryExcludingFireEvent
-
 const environment = setup()
 export const act = environment.act
 export const render = environment.render
 export const cleanup = environment.cleanup
+// eslint-disable-next-line import/export
+export * from '@testing-library/dom'
+// eslint-disable-next-line import/export
 export const fireEvent = environment.fireEvent


### PR DESCRIPTION
The renderer sets up the `fireEvent` function to call the correct `act` implementation. However this wrapped `fireEvent` is not actually exported from the package, and instead the "empty" `fireEvent` from `testing-library` is exported instead.

This PR exports the correctly wrapped `fireEvent` function for use.