### PR TITLE
Update the useSharedFacet typing

### DIFF
--- a/packages/@react-facet/shared-facet/src/context.ts
+++ b/packages/@react-facet/shared-facet/src/context.ts
@@ -8,6 +8,8 @@ export const sharedFacetDriverContext = createContext<SharedFacetDriver>(dummyCo
 
 export const SharedFacetDriverProvider = sharedFacetDriverContext.Provider
 
-export const useSharedFacet = <T>(sharedFacet: SharedFacet<T>): Facet<T> => {
-  return sharedFacet(useContext(sharedFacetDriverContext))
+type InferFacet<T> = T extends SharedFacet<infer U> ? Facet<U> : never
+
+export const useSharedFacet = <T extends SharedFacet<unknown>>(sharedFacet: T): InferFacet<T> => {
+  return sharedFacet(useContext(sharedFacetDriverContext)) as InferFacet<T>
 }


### PR DESCRIPTION
Typescript enforces invariance in generics which means that the `useSharedFacet` requires a single specific type. This leads to type errors when trying to pass a union, e.g:

```typescript
const sharedFacet = getFacet(worldMode) // SharedFacet<CreateNewWorldFacet> | SharedFacet<WorldEditorFacet> | SharedFacet<RealmWorldEditorFacet>
const regularFacetUnion = useSharedFacet(sharedFacetUnion) // This errors because the types are not assignable to each other.
```

However, with the changes I'm introducing here the hook now leverages conditional types with infer to automatically distribute over unions. So when a union of shared facets is passed to `useSharedFacet`, the return type becomes a union of the corresponding facet types. Which means that the `regularFacetUnion` above will be of type `Facet<CreateNewWorldFacet> | Facet<WorldEditorFacet> | Facet<RealmWorldEditorFacet>`.


We are then able to use that facet union with our other hooks like `useFacetMap`:

```typescript
const f = useFacetMap(
	(f) => {
		if ('worldData' in f) {
			return f.worldData
		}
		if ('realmWorldData' in f) {
			return f.realmWorldData
		}
	},
	[],
	[regularFacetUnion],
)
```

One downside is that the updated implementation now uses a type assertion (`as InferFacet<T>`) because typescript cannot automatically verify that the value returned by `sharedFacet(driver)` conforms to the conditional type. However, I believe that this cast is always safe based on the functions behaviour.