### PR TITLE
Allow facets to be used as an initial value of useFacetState

### DIFF
--- a/docs/docs/api/hooks/use-facet-state.md
+++ b/docs/docs/api/hooks/use-facet-state.md
@@ -187,3 +187,48 @@ const Examples = () => {
   return <div>Examples</div>
 }
 ```
+
+## Initializing from Another Facet
+
+`useFacetState` can accept another facet as its initial value. The current value of the source facet is read once during initialization — subsequent changes to the source facet are **not** propagated to the new facet.
+
+This is useful when you need independent local state that starts with the same value as an existing facet:
+
+```tsx twoslash
+// @esModuleInterop
+import { render } from '@react-facet/dom-fiber'
+// ---cut---
+import { useFacetState, useFacetCallback, Facet } from '@react-facet/core'
+
+type Props = {
+  nameFacet: Facet<string>
+  onSave: (name: string) => void
+}
+
+const EditNameForm = ({ nameFacet, onSave }: Props) => {
+  // Initialize local state from the shared facet — edits stay local
+  const [localNameFacet, setLocalName] = useFacetState(nameFacet)
+
+  const handleSave = useFacetCallback(
+    (name) => () => {
+      onSave(name)
+    },
+    [onSave],
+    [localNameFacet],
+  )
+
+  return (
+    <fast-div>
+      <fast-input
+        value={localNameFacet}
+        onKeyUp={(e) => {
+          if (e.target instanceof HTMLInputElement) {
+            setLocalName(e.target.value)
+          }
+        }}
+      />
+      <fast-div onClick={handleSave}>Save</fast-div>
+    </fast-div>
+  )
+}
+```

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2685,7 +2685,7 @@ __metadata:
   dependencies:
     react-reconciler: ^0.28.0
   peerDependencies:
-    "@react-facet/core": 18.4.0
+    "@react-facet/core": 18.5.0
     react: ^18.2.0
   languageName: node
   linkType: soft
@@ -2694,7 +2694,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-facet/shared-facet@portal:../packages/@react-facet/shared-facet::locator=ore-ui-docs%40workspace%3A."
   peerDependencies:
-    "@react-facet/core": 18.4.0
+    "@react-facet/core": 18.5.0
     react: ^18.2.0
   languageName: node
   linkType: soft

--- a/packages/@react-facet/core/src/hooks/useFacetState.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetState.spec.tsx
@@ -3,6 +3,7 @@ import { act, render } from '@react-facet/dom-fiber-testing-library'
 import { Setter, NO_VALUE } from '../types'
 import { useFacetState } from './useFacetState'
 import { useFacetEffect } from './useFacetEffect'
+import { createFacet } from '../facet'
 
 it('first value is the facet, second is the setter', () => {
   let setAdaptValue: Setter<string>
@@ -65,4 +66,30 @@ it('memoizes the setter', () => {
   rerender(<ComponentWithFacetEffect />)
 
   expect(setter).toBe(savedSetter)
+})
+
+it('supports initialization from another facet', () => {
+  const anotherFacet = createFacet({ initialValue: 'initial value' })
+
+  const ComponentWithFacetEffect = () => {
+    const [facet] = useFacetState(anotherFacet)
+
+    return (
+      <span>
+        <fast-text text={facet} />
+      </span>
+    )
+  }
+
+  const scenario = <ComponentWithFacetEffect />
+
+  const { container } = render(scenario)
+  expect(container.textContent).toBe('initial value')
+
+  act(() => {
+    anotherFacet.set('changed')
+  })
+
+  // The other facet's value should only be used for initialization
+  expect(container.textContent).toBe('initial value')
 })

--- a/packages/@react-facet/core/src/hooks/useFacetState.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetState.spec.tsx
@@ -96,12 +96,15 @@ it('supports initialization from another facet', () => {
 
 it('supports initialization from another facet that has a startSubscription', () => {
   const subscribed = jest.fn()
+  const cleanedUp = jest.fn()
 
   const anotherFacet = createFacet<string>({
     startSubscription: (update) => {
       subscribed()
       update('initial value')
-      return () => {}
+      return () => {
+        cleanedUp()
+      }
     },
     initialValue: NO_VALUE,
   })
@@ -116,10 +119,15 @@ it('supports initialization from another facet that has a startSubscription', ()
   const { container, rerender } = render(<ComponentWithFacetEffect />)
   expect(container.textContent).toBe('')
   expect(subscribed).not.toHaveBeenCalled()
+  expect(cleanedUp).not.toHaveBeenCalled()
 
   // But, once we depend on the state that should be initialized by the depending facet
   // then the subscription is started, and the initial value is shown
   rerender(<ComponentWithFacetEffect showText />)
   expect(container.textContent).toBe('initial value')
   expect(subscribed).toHaveBeenCalled()
+
+  // Given we need the subscription just to have the initial value
+  // We immediately unsubscribe on setup
+  expect(cleanedUp).toHaveBeenCalled()
 })

--- a/packages/@react-facet/core/src/hooks/useFacetState.spec.tsx
+++ b/packages/@react-facet/core/src/hooks/useFacetState.spec.tsx
@@ -93,3 +93,33 @@ it('supports initialization from another facet', () => {
   // The other facet's value should only be used for initialization
   expect(container.textContent).toBe('initial value')
 })
+
+it('supports initialization from another facet that has a startSubscription', () => {
+  const subscribed = jest.fn()
+
+  const anotherFacet = createFacet<string>({
+    startSubscription: (update) => {
+      subscribed()
+      update('initial value')
+      return () => {}
+    },
+    initialValue: NO_VALUE,
+  })
+
+  const ComponentWithFacetEffect = ({ showText }: { showText?: boolean }) => {
+    const [facet] = useFacetState(anotherFacet)
+    return <span>{showText ? <fast-text text={facet} /> : null}</span>
+  }
+
+  // Initially, the state is not used, so the dependency should not be subscribed
+  // and no text should be shown
+  const { container, rerender } = render(<ComponentWithFacetEffect />)
+  expect(container.textContent).toBe('')
+  expect(subscribed).not.toHaveBeenCalled()
+
+  // But, once we depend on the state that should be initialized by the depending facet
+  // then the subscription is started, and the initial value is shown
+  rerender(<ComponentWithFacetEffect showText />)
+  expect(container.textContent).toBe('initial value')
+  expect(subscribed).toHaveBeenCalled()
+})

--- a/packages/@react-facet/core/src/hooks/useFacetState.ts
+++ b/packages/@react-facet/core/src/hooks/useFacetState.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { defaultEqualityCheck } from '../equalityChecks'
 import { createFacet } from '../facet'
-import { EqualityCheck, Facet, Option, Setter } from '../types'
+import { EqualityCheck, Facet, isFacet, NO_VALUE, Option, Setter } from '../types'
 
 /**
  * Provides a parallel to React's useState, but instead returns a facet as the value
@@ -10,11 +10,28 @@ import { EqualityCheck, Facet, Option, Setter } from '../types'
  * @param equalityCheck optional (has a default checker)
  */
 export const useFacetState = <V>(
-  initialValue: Option<V>,
+  initialValue: Option<V> | Facet<V>,
   equalityCheck: EqualityCheck<V> = defaultEqualityCheck,
 ): [Facet<V>, Setter<V>] => {
   return useMemo(() => {
-    const inlineFacet = createFacet<V>({ initialValue, equalityCheck })
+    const inlineFacet = isFacet(initialValue)
+      ? createFacet<V>({
+          initialValue: initialValue.get(),
+          startSubscription: (update) => {
+            const cleanup = initialValue.observe(() => {})
+
+            const properInitialValue = initialValue.get()
+            if (properInitialValue !== NO_VALUE) {
+              update(properInitialValue)
+            }
+
+            cleanup()
+
+            return () => {}
+          },
+        })
+      : createFacet<V>({ initialValue, equalityCheck })
+
     const setter: Setter<V> = (setter) => {
       if (isSetterCallback(setter)) {
         inlineFacet.setWithCallback(setter)

--- a/packages/@react-facet/core/src/types.ts
+++ b/packages/@react-facet/core/src/types.ts
@@ -55,7 +55,7 @@ export type Cleanup = Unsubscribe
 
 export type StartSubscription<V> = (update: Update<V>) => Cleanup
 
-export const isFacet = <T>(value: Value | Facet<T>): value is Facet<T> => {
+export const isFacet = <T>(value: T | Facet<T>): value is Facet<T> => {
   return (
     value !== null &&
     value !== undefined &&


### PR DESCRIPTION
The change ensures that we setup an initial subscription to get the value. Currently achieving the same functionality requires additional effects in user-land code.

```tsx
const anotherFacet = createFacet({ initialValue: 'initial value' })

const ExampleComponent = () => {
  const [facet, setFacet] = useFacetState(anotherFacet)

  return (
    <span>
      <fast-text text={facet} />
    </span>
  )
}
```